### PR TITLE
Fix arithmetic and control flow bugs in batch programs

### DIFF
--- a/app/cbl/CBACT04C.cbl
+++ b/app/cbl/CBACT04C.cbl
@@ -461,7 +461,7 @@
       *---------------------------------------------------------------*         
        1300-COMPUTE-INTEREST.                                                   
                                                                                 
-           COMPUTE WS-MONTHLY-INT                                               
+           COMPUTE WS-MONTHLY-INT ROUNDED
             = ( TRAN-CAT-BAL * DIS-INT-RATE) / 1200                             
                                                                                 
            ADD WS-MONTHLY-INT  TO WS-TOTAL-INT                                  

--- a/app/cbl/CBTRN02C.cbl
+++ b/app/cbl/CBTRN02C.cbl
@@ -400,8 +400,8 @@
               NOT INVALID KEY                                                   
       *         DISPLAY 'ACCT-CREDIT-LIMIT:' ACCT-CREDIT-LIMIT                  
       *         DISPLAY 'TRAN-AMT         :' DALYTRAN-AMT                       
-                COMPUTE WS-TEMP-BAL = ACCT-CURR-CYC-CREDIT                      
-                                    - ACCT-CURR-CYC-DEBIT                       
+                COMPUTE WS-TEMP-BAL = ACCT-CURR-CYC-CREDIT
+                                    + ACCT-CURR-CYC-DEBIT
                                     + DALYTRAN-AMT                              
                                                                                 
                 IF ACCT-CREDIT-LIMIT >= WS-TEMP-BAL                             
@@ -551,11 +551,12 @@
               ADD DALYTRAN-AMT TO ACCT-CURR-CYC-DEBIT                           
            END-IF                                                               
                                                                                 
-           REWRITE FD-ACCTFILE-REC FROM  ACCOUNT-RECORD                         
-              INVALID KEY                                                       
-                MOVE 109 TO WS-VALIDATION-FAIL-REASON                           
-                MOVE 'ACCOUNT RECORD NOT FOUND'                                 
-                  TO WS-VALIDATION-FAIL-REASON-DESC                             
+           REWRITE FD-ACCTFILE-REC FROM  ACCOUNT-RECORD
+              INVALID KEY
+                DISPLAY 'ERROR REWRITING ACCOUNT FILE'
+                MOVE ACCTFILE-STATUS TO IO-STATUS
+                PERFORM 9910-DISPLAY-IO-STATUS
+                PERFORM 9999-ABEND-PROGRAM
            END-REWRITE.                                                         
            EXIT.                                                                
       *---------------------------------------------------------------*         
@@ -645,13 +646,13 @@
            IF  APPL-AOK                                                         
                CONTINUE                                                         
            ELSE                                                                 
-               DISPLAY 'ERROR CLOSING DAILY REJECTS FILE'                       
-               MOVE XREFFILE-STATUS TO IO-STATUS                                
-               PERFORM 9910-DISPLAY-IO-STATUS                                   
-               PERFORM 9999-ABEND-PROGRAM                                       
-           END-IF                                                               
-           EXIT.                                                                
-      *---------------------------------------------------------------*         
+               DISPLAY 'ERROR CLOSING DAILY REJECTS FILE'
+               MOVE DALYREJS-STATUS TO IO-STATUS
+               PERFORM 9910-DISPLAY-IO-STATUS
+               PERFORM 9999-ABEND-PROGRAM
+           END-IF
+           EXIT.
+      *---------------------------------------------------------------*
        9400-ACCTFILE-CLOSE.                                                     
            MOVE 8 TO APPL-RESULT.                                               
            CLOSE ACCOUNT-FILE                                                   

--- a/app/cbl/CBTRN03C.cbl
+++ b/app/cbl/CBTRN03C.cbl
@@ -167,42 +167,37 @@
                                                                                 
            PERFORM 0550-DATEPARM-READ.                                          
                                                                                 
-           PERFORM UNTIL END-OF-FILE = 'Y'                                      
-             IF END-OF-FILE = 'N'                                               
-                PERFORM 1000-TRANFILE-GET-NEXT                                  
-                IF TRAN-PROC-TS (1:10) >= WS-START-DATE                         
-                   AND TRAN-PROC-TS (1:10) <= WS-END-DATE                       
-                   CONTINUE                                                     
-                ELSE                                                            
-                   NEXT SENTENCE                                                
-                END-IF                                                          
-                IF END-OF-FILE = 'N'                                            
-                   DISPLAY TRAN-RECORD                                          
-                   IF WS-CURR-CARD-NUM NOT= TRAN-CARD-NUM                       
-                     IF WS-FIRST-TIME = 'N'                                     
-                       PERFORM 1120-WRITE-ACCOUNT-TOTALS                        
-                     END-IF                                                     
-                     MOVE TRAN-CARD-NUM TO WS-CURR-CARD-NUM                     
-                     MOVE TRAN-CARD-NUM TO FD-XREF-CARD-NUM                     
-                     PERFORM 1500-A-LOOKUP-XREF                                 
-                   END-IF                                                       
-                   MOVE TRAN-TYPE-CD OF TRAN-RECORD TO FD-TRAN-TYPE             
-                   PERFORM 1500-B-LOOKUP-TRANTYPE                               
-                   MOVE TRAN-TYPE-CD OF TRAN-RECORD                             
-                     TO FD-TRAN-TYPE-CD OF FD-TRAN-CAT-KEY                      
-                   MOVE TRAN-CAT-CD OF TRAN-RECORD                              
-                     TO FD-TRAN-CAT-CD OF FD-TRAN-CAT-KEY                       
-                   PERFORM 1500-C-LOOKUP-TRANCATG                               
-                   PERFORM 1100-WRITE-TRANSACTION-REPORT                        
-                ELSE                                                            
-                 DISPLAY 'TRAN-AMT ' TRAN-AMT                                   
-                 DISPLAY 'WS-PAGE-TOTAL'  WS-PAGE-TOTAL                         
-                 ADD TRAN-AMT TO WS-PAGE-TOTAL                                  
-                                 WS-ACCOUNT-TOTAL                               
-                 PERFORM 1110-WRITE-PAGE-TOTALS                                 
-                 PERFORM 1110-WRITE-GRAND-TOTALS                                
-                END-IF                                                          
-             END-IF                                                             
+           PERFORM UNTIL END-OF-FILE = 'Y'
+             IF END-OF-FILE = 'N'
+                PERFORM 1000-TRANFILE-GET-NEXT
+                IF END-OF-FILE = 'N'
+                   IF TRAN-PROC-TS (1:10) >= WS-START-DATE
+                      AND TRAN-PROC-TS (1:10) <= WS-END-DATE
+                     DISPLAY TRAN-RECORD
+                     IF WS-CURR-CARD-NUM NOT= TRAN-CARD-NUM
+                       IF WS-FIRST-TIME = 'N'
+                         PERFORM 1120-WRITE-ACCOUNT-TOTALS
+                       END-IF
+                       MOVE TRAN-CARD-NUM TO WS-CURR-CARD-NUM
+                       MOVE TRAN-CARD-NUM TO FD-XREF-CARD-NUM
+                       PERFORM 1500-A-LOOKUP-XREF
+                     END-IF
+                     MOVE TRAN-TYPE-CD OF TRAN-RECORD
+                       TO FD-TRAN-TYPE
+                     PERFORM 1500-B-LOOKUP-TRANTYPE
+                     MOVE TRAN-TYPE-CD OF TRAN-RECORD
+                       TO FD-TRAN-TYPE-CD OF FD-TRAN-CAT-KEY
+                     MOVE TRAN-CAT-CD OF TRAN-RECORD
+                       TO FD-TRAN-CAT-CD OF FD-TRAN-CAT-KEY
+                     PERFORM 1500-C-LOOKUP-TRANCATG
+                     PERFORM 1100-WRITE-TRANSACTION-REPORT
+                   END-IF
+                ELSE
+                   PERFORM 1120-WRITE-ACCOUNT-TOTALS
+                   PERFORM 1110-WRITE-PAGE-TOTALS
+                   PERFORM 1110-WRITE-GRAND-TOTALS
+                END-IF
+             END-IF
            END-PERFORM.                                                         
                                                                                 
            PERFORM 9000-TRANFILE-CLOSE.                                         


### PR DESCRIPTION
Hi there,

Was reading through the batch programs and noticed a few issues that could cause incorrect results in production:

**CBACT04C** (Interest Calculator):
- `COMPUTE WS-MONTHLY-INT` was missing `ROUNDED`, causing interest to be systematically truncated rather than rounded. For a rate of 21.50% on a $10,000 balance, this means $179.16 instead of $179.17 — adds up across accounts.

**CBTRN02C** (Transaction Posting):
- Credit limit validation uses `CREDIT - DEBIT`, but `ACCT-CURR-CYC-DEBIT` already stores negative values (payments are added via `ADD negative-amount`). So `3000 - (-2000)` = 5000 instead of 1000. This causes valid transactions to be rejected as overlimit after the customer makes payments.
- `REWRITE` failure on account file was silently ignored — transaction gets written but balance never updates.
- `9300-DALYREJS-CLOSE` was displaying `XREFFILE-STATUS` instead of `DALYREJS-STATUS` (copy-paste).

**CBTRN03C** (Transaction Report):
- `NEXT SENTENCE` inside an inline `PERFORM...END-PERFORM` transfers control past the `END-PERFORM.` period, effectively breaking out of the loop on the first out-of-range transaction. Replaced with a nested `IF` for proper date filtering.
- EOF branch was adding stale `TRAN-AMT` to totals (last record counted twice).

All changes are minimal and isolated — no new fields, no copybook changes, no interface changes.

Cheers

Made with [Cursor](https://cursor.com)