### PR TITLE
RAU-37: Domain models — port copybooks to Go structs + COBOL data-format helpers

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,38 @@
+version: "2"
+
+linters:
+  enable:
+    - errcheck
+    - govet
+    - ineffassign
+    - staticcheck
+    - unused
+    - misspell
+    - unconvert
+    - unparam
+
+linters-settings:
+  errcheck:
+    exclude-functions:
+      - (io.Closer).Close
+      - (net/http.ResponseWriter).Write
+
+formatters:
+  enable:
+    - gofmt
+    - goimports
+
+formatters-settings:
+  goimports:
+    local-prefixes:
+      - github.com/aws-samples/aws-mainframe-modernization-carddemo
+
+issues:
+  exclude-rules:
+    - source: "Body\\.Close"
+      linters:
+        - errcheck
+    - path: ".*_test.go"
+      linters:
+        - unparam
+        - errcheck

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,41 @@
+.PHONY: build test lint vet tidy run-web run-batch clean help
+
+# Set RACE=1 to enable the race detector (requires CGO; skip for sqlite-backed tests).
+RACE   ?=
+GOTEST := go test $(if $(RACE),-race,) ./...
+
+## build: compile all binaries
+build:
+	go build ./...
+
+## test: run the full test suite
+test:
+	$(GOTEST)
+
+## lint: run golangci-lint
+lint:
+	golangci-lint run ./...
+
+## vet: run go vet
+vet:
+	go vet ./...
+
+## tidy: update go.sum and remove unused dependencies
+tidy:
+	go mod tidy
+
+## run-web: start the CardDemo online (CICS) web server
+run-web:
+	go run ./cmd/web
+
+## run-batch: print batch subcommand usage
+run-batch:
+	go run ./cmd/batch
+
+## clean: remove build artifacts
+clean:
+	go clean ./...
+
+## help: list available targets
+help:
+	@grep -E '^## ' Makefile | sed 's/## //'

--- a/cmd/batch/main.go
+++ b/cmd/batch/main.go
@@ -1,0 +1,38 @@
+// Command batch is the CardDemo batch CLI.
+// Each subcommand replaces one JCL step in the original job stream.
+// RAU-44 (batch layer) wires in the per-step subcommands; this stub
+// prints usage so the binary compiles and the build gate passes now.
+//
+// JCL → subcommand mapping (to be implemented in internal/batch):
+//
+//	CBTRN01C / POSTTRAN.jcl   → batch post-transaction
+//	CBTRN02C / TRANCATG.jcl   → batch categorize-transaction
+//	CBTRN03C / DALYREJS.jcl   → batch daily-rejects
+//	CBACT01C / ACCTFILE.jcl   → batch account-file
+//	CBACT02C / INTCALC.jcl    → batch interest-calc
+//	CBACT03C / TCATBALF.jcl   → batch tcat-balance
+//	CBACT04C / READACCT.jcl   → batch read-account
+//	CBCUS01C / CUSTFILE.jcl   → batch customer-file
+//	CBSTM03A / CREASTMT.JCL   → batch create-statement
+//	CBSTM03B / REPTFILE.jcl   → batch report-file
+//	CBEXPORT / CBEXPORT.jcl   → batch export
+//	CBIMPORT / CBIMPORT.jcl   → batch import
+package main
+
+import (
+	"fmt"
+	"os"
+)
+
+func main() {
+	fmt.Fprintf(os.Stderr, "usage: carddemo-batch <subcommand> [flags]\n\n")
+	fmt.Fprintf(os.Stderr, "Subcommands (stub — RAU-44 will implement these):\n")
+	fmt.Fprintf(os.Stderr, "  post-transaction       CBTRN01C / POSTTRAN.jcl\n")
+	fmt.Fprintf(os.Stderr, "  categorize-transaction CBTRN02C / TRANCATG.jcl\n")
+	fmt.Fprintf(os.Stderr, "  daily-rejects          CBTRN03C / DALYREJS.jcl\n")
+	fmt.Fprintf(os.Stderr, "  interest-calc          CBACT02C / INTCALC.jcl\n")
+	fmt.Fprintf(os.Stderr, "  create-statement       CBSTM03A / CREASTMT.JCL\n")
+	fmt.Fprintf(os.Stderr, "  export                 CBEXPORT / CBEXPORT.jcl\n")
+	fmt.Fprintf(os.Stderr, "  import                 CBIMPORT / CBIMPORT.jcl\n")
+	os.Exit(1)
+}

--- a/cmd/carddemo/main.go
+++ b/cmd/carddemo/main.go
@@ -1,0 +1,67 @@
+// Command carddemo is a thin wiring binary that boots the auth + admin user
+// HTTP server. RAU-43 (web layer) will replace this with the full app entrypoint.
+package main
+
+import (
+	"context"
+	"log"
+	"net/http"
+	"os"
+	"time"
+
+	"github.com/aws-samples/aws-mainframe-modernization-carddemo/internal/audit"
+	authpkg "github.com/aws-samples/aws-mainframe-modernization-carddemo/internal/auth"
+	"github.com/aws-samples/aws-mainframe-modernization-carddemo/internal/repo"
+	webauth "github.com/aws-samples/aws-mainframe-modernization-carddemo/internal/web/auth"
+)
+
+func main() {
+	addr := os.Getenv("CARDDEMO_ADDR")
+	if addr == "" {
+		addr = ":8080"
+	}
+
+	users := repo.NewInMemoryUserSec()
+	if err := authpkg.SeedDefaultUsers(context.Background(), users, 0); err != nil {
+		log.Fatalf("seed: %v", err)
+	}
+	sink := audit.NewMemorySink()
+	store := authpkg.NewMemorySessionStore()
+	svc := authpkg.NewService(users, store, sink)
+
+	h := webauth.NewHandlers(svc)
+	if os.Getenv("CARDDEMO_INSECURE_COOKIES") == "1" {
+		h.CookieOptions.Secure = false // dev/local only — never set this in prod
+	}
+
+	mux := http.NewServeMux()
+	loadSession := authpkg.LoadSession(store)
+	requireAdmin := authpkg.RequireAdmin(sink, h.LoginPath)
+	csrf := authpkg.CSRFProtect()
+
+	publicMux := http.NewServeMux()
+	publicMux.HandleFunc("GET /login", h.GetLogin)
+	publicMux.HandleFunc("POST /login", h.PostLogin)
+	publicMux.HandleFunc("POST /logout", h.PostLogout)
+
+	adminMux := http.NewServeMux()
+	adminMux.HandleFunc("GET /admin/users", h.ListUsers)
+	adminMux.HandleFunc("POST /admin/users", h.CreateUser)
+	adminMux.HandleFunc("GET /admin/users/{id}", h.GetUser)
+	adminMux.HandleFunc("POST /admin/users/{id}", h.UpdateUser)
+	adminMux.HandleFunc("POST /admin/users/{id}/delete", h.DeleteUser)
+
+	mux.Handle("/login", publicMux)
+	mux.Handle("/logout", publicMux)
+	mux.Handle("/admin/", requireAdmin(adminMux))
+
+	srv := &http.Server{
+		Addr:              addr,
+		Handler:           loadSession(csrf(mux)),
+		ReadHeaderTimeout: 10 * time.Second,
+	}
+	log.Printf("carddemo listening on %s", addr)
+	if err := srv.ListenAndServe(); err != nil {
+		log.Fatal(err)
+	}
+}

--- a/cmd/web/main.go
+++ b/cmd/web/main.go
@@ -1,0 +1,28 @@
+// Command web is the CardDemo online (CICS) front-end server.
+// It replaces all BMS-screen-driven CICS transactions with an HTTP/HTML app.
+// RAU-43 (web layer) wires in the chi router and per-screen handlers;
+// this stub boots a minimal health-check server so the binary compiles now.
+package main
+
+import (
+	"log"
+	"net/http"
+	"os"
+)
+
+func main() {
+	addr := os.Getenv("CARDDEMO_WEB_ADDR")
+	if addr == "" {
+		addr = ":8080"
+	}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/healthz", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	log.Printf("carddemo-web listening on %s", addr)
+	if err := http.ListenAndServe(addr, mux); err != nil {
+		log.Fatalf("web server: %v", err)
+	}
+}

--- a/configs/orchestrator.yaml.example
+++ b/configs/orchestrator.yaml.example
@@ -1,0 +1,30 @@
+# CardDemo batch orchestrator configuration (example).
+# Copy to orchestrator.yaml and adjust paths for your environment.
+# Each job lists its steps in execution order; steps are run by cmd/batch.
+
+jobs:
+  daily-transaction-processing:
+    description: "Daily transaction post and categorisation (replaces POSTTRAN.jcl + TRANCATG.jcl)"
+    steps:
+      - name: post-transaction
+        cmd: carddemo-batch post-transaction
+        args: ["--input", "/data/transactions/daily.dat"]
+      - name: categorize-transaction
+        cmd: carddemo-batch categorize-transaction
+        args: ["--date", "today"]
+      - name: daily-rejects
+        cmd: carddemo-batch daily-rejects
+        args: ["--output", "/data/rejects/daily.dat"]
+
+  monthly-statement:
+    description: "Monthly statement generation (replaces CREASTMT.JCL + REPTFILE.jcl)"
+    steps:
+      - name: interest-calc
+        cmd: carddemo-batch interest-calc
+        args: ["--month", "current"]
+      - name: create-statement
+        cmd: carddemo-batch create-statement
+        args: ["--output-dir", "/data/statements"]
+      - name: report-file
+        cmd: carddemo-batch report-file
+        args: ["--output", "/data/reports/monthly.rpt"]

--- a/docs/adr/0001-auth-architecture.md
+++ b/docs/adr/0001-auth-architecture.md
@@ -1,0 +1,67 @@
+# ADR 0001 — Authentication & user management architecture (RAU-39)
+
+## Status
+Accepted (pending appsec sign-off, RAU-46).
+
+## Context
+The legacy CardDemo application authenticates via RACF + CICS sign-on map
+(`COSGN00C.cbl` / `COSGN00.bms`) and manages users with four CICS programs
+(`COUSR00C`/`01C`/`02C`/`03C`) reading and writing the `USRSEC` VSAM file
+(`CSUSR01Y.cpy`, 80-byte record, 8-character cleartext password). RAU-39
+replaces this with a Go HTTP application.
+
+## Decision
+
+### Authentication
+- Server-side, opaque session IDs in `carddemo_sid` cookie (HttpOnly, Secure, SameSite=Lax).
+- bcrypt password hashing (`golang.org/x/crypto/bcrypt`); compare via
+  `bcrypt.CompareHashAndPassword` (constant-time).
+- Per-IP **and** per-username rate limiting (fixed window, default 15-minute
+  window with 5 attempts per user / 20 per IP). On lockout, even the correct
+  password is rejected for the remainder of the window.
+- Audit log entry on every login attempt (success or failure) and every admin
+  user mutation. Audit `Reason` differentiates failure modes for ops; the
+  public error is always the same (`invalid credentials`) so user existence
+  does not leak.
+
+### CSRF
+- Double-submit cookie. The `carddemo_csrf` cookie is set by the server (not
+  HttpOnly) and the value is mirrored in a hidden form field / `X-CSRF-Token`
+  header. State-changing requests are rejected unless the two match in
+  constant time.
+- The same cookie name is used pre- and post-login: `GET /login` issues a
+  short-lived token bound to the browser, and successful login replaces it
+  with a session-bound token rotated on each new session.
+
+### Authorization
+- Role check on `domain.UserType` (`A` admin, `U` user). `RequireAdmin`
+  middleware records `access.denied` audit events on probing.
+
+### Persistence
+- `internal/repo.UserSecRepo` interface — RAU-38 will provide the persistent
+  implementation. The current `InMemoryUserSec` is sufficient for dev and
+  tests.
+
+### Seeding
+- `auth.SeedDefaultUsers` replaces the legacy cleartext credentials
+  (`ADMIN001/PASSWORD`, `USER0001/PASSWORD`) with bcrypt hashes during the
+  seed step. No cleartext password ever reaches storage.
+
+## Out of scope (future work)
+- **OIDC / SAML federation** — explicitly excluded from this issue. When
+  delivered, federated identities will live alongside the local UserSec store
+  and reuse the same session/audit primitives. (Tracking with RAU-16 for Entra
+  ID and RAU-25 for SSO setup docs.)
+- **Self-service password reset** — explicitly excluded. The current admin
+  UI lets administrators rotate any user's password; end-user reset will be
+  added later with a separate token + email flow.
+
+## Consequences
+- The HTTP edge depends on bcrypt's cost; tests use cost 4 to keep them fast,
+  production defaults to bcrypt's `DefaultCost` (10).
+- `httptest` does not run TLS, so unit tests toggle `CookieOptions.Secure=false`.
+  `auth.DefaultCookieOptions()` is verified in tests to ensure production
+  cookies are always Secure.
+- The in-memory rate limiter is per-process. If this is ever fronted by
+  multiple replicas, swap `RateLimiter` for a shared store (Redis) without
+  changing call sites.

--- a/docs/adr/0002-module-layout.md
+++ b/docs/adr/0002-module-layout.md
@@ -1,0 +1,31 @@
+# ADR 0002 — Go module layout
+
+**Status:** Accepted (RAU-36)
+**Decided:** 2026-06-02 (Connector ruling, resolving Option A vs B)
+
+## Context
+
+The original scaffold placed the Go module in a `carddemo-go/` subdirectory (Option B).
+RAU-39 committed auth code at the repo root with module path
+`github.com/aws-samples/aws-mainframe-modernization-carddemo` and go 1.26.2.
+The Connector closed the layout question as Option A (root-level) based on:
+- The RAU-36 spec says "go.mod at repo root".
+- RAU-39's root module builds and tests pass on go 1.26.2; the `carddemo-go/` layout was never committed.
+- Migrating RAU-39's working code into a subdir costs more than backfilling the scaffold around it.
+
+## Decision
+
+**Option A — root-level module.**
+
+- Module path: `github.com/aws-samples/aws-mainframe-modernization-carddemo`
+- `go.mod` at repo root, `go 1.26.2`.
+- Entry points: `cmd/web/` (CICS online replacement) and `cmd/batch/` (JCL batch replacement).
+  `cmd/carddemo/` from RAU-39 remains during the migration period; RAU-43 will consolidate into `cmd/web`.
+- Internal packages: `internal/{domain,repo,service,web,batch,cobolfmt,auth,audit}`.
+- Dependency direction: `cmd → service → domain`; `service → repo` (interface); `repo` imports `domain`; no cycles.
+
+## Consequences
+
+- All downstream issues (RAU-37 through RAU-45) import from `github.com/aws-samples/aws-mainframe-modernization-carddemo/internal/...`.
+- A future `cmd/carddemo` → `cmd/web` consolidation is a rename; it does not change module paths.
+- ADR numbering: 0001 is RAU-39's auth-architecture; scaffold decisions start at 0002.

--- a/docs/adr/0003-http-framework.md
+++ b/docs/adr/0003-http-framework.md
@@ -1,0 +1,30 @@
+# ADR 0003 — HTTP framework
+
+**Status:** Accepted (RAU-36)
+
+## Context
+
+The online CICS application drives BMS screens via terminal I/O. The Go port needs an
+HTTP router and middleware stack to replace that interaction model. Standard library
+`net/http` is sufficient for handlers; routing (URL params, grouped middleware) benefits
+from a thin layer.
+
+## Decision
+
+**stdlib `net/http` + `github.com/go-chi/chi/v5`.**
+
+- All handlers implement `http.Handler` — no framework lock-in.
+- chi provides URL parameter extraction (`chi.URLParam`), route grouping, and
+  middleware chaining (auth, CSRF, logging) without reflection magic.
+- No SPA framework; `html/template` renders each BMS screen replacement (ADR 0005).
+
+## Alternatives considered
+
+- `gin`: heavier, opinionated on error handling; chi is closer to stdlib.
+- `echo`: similar to gin; adds a custom context type that complicates handler testing.
+- Pure `net/http` with `ServeMux`: path-parameter routing is verbose; chi is worth the dependency.
+
+## Consequences
+
+- Handlers can be tested with `httptest.NewRecorder` + `http.NewRequest` without a running server.
+- chi middleware (auth gate, CSRF, request-ID) is wired in `internal/web` and composed in `cmd/web/main.go`.

--- a/docs/adr/0004-persistence.md
+++ b/docs/adr/0004-persistence.md
@@ -1,0 +1,32 @@
+# ADR 0004 — Persistence: replacing VSAM KSDS
+
+**Status:** Accepted (RAU-36)
+
+## Context
+
+CardDemo uses five VSAM KSDS files as its primary data store:
+`USRSEC`, `ACCTDAT`, `CARDDAT`, `CUSTDAT`, `TRANSACT`, and `CARDXREF`.
+VSAM is mainframe-only and cannot be used in a Go application.
+
+## Decision
+
+**Single relational backend, accessed through repository interfaces only.**
+
+- Development and integration tests: `modernc.org/sqlite` (pure Go, no CGO required).
+- Production: `github.com/jackc/pgx/v5/stdlib` (PostgreSQL-compatible driver).
+- All SQL is confined to `internal/repo`; no raw SQL in handlers or services.
+- Repository interfaces are defined in `internal/repo`; implementations satisfy those interfaces.
+  Services import the interface, not the concrete type — swapping SQLite for Postgres requires
+  only a one-line change in the wiring code.
+
+## Alternatives considered
+
+- Pure in-memory maps: already used for tests in RAU-39; not suitable for persistence or multi-instance.
+- GORM: adds a reflection-heavy ORM layer that obscures SQL and makes migrations harder to reason about.
+- Direct Postgres only: CGO-free SQLite lets integration tests run without a running Postgres instance.
+
+## Consequences
+
+- Schema migrations live in `internal/repo/migrations/` (SQL files, applied by the repo init path).
+- The test harness creates an in-memory SQLite DB per test using `modernc.org/sqlite`.
+- Production deploys set `DATABASE_URL` to a Postgres DSN; the wiring in `cmd/web/main.go` switches driver.

--- a/docs/adr/0005-templating-ui.md
+++ b/docs/adr/0005-templating-ui.md
@@ -1,0 +1,45 @@
+# ADR 0005 — Templating and UI: BMS screen replacement
+
+**Status:** Accepted (RAU-36)
+
+## Context
+
+Each CICS transaction in CardDemo has a BMS map that defines a terminal screen layout
+(field positions, attributes, colours). The Go port must replace these with web pages.
+
+## Decision
+
+**`html/template` + minimal CSS, one HTML file per BMS map. No SPA.**
+
+- Each BMS map becomes one Go `html/template` template under `internal/web/<domain>/templates/`.
+- Templates are embedded into the binary via `embed.FS`.
+- Styling is minimal, utility-CSS-based; no JavaScript framework.
+- Forms POST back to the same or a redirect URL; no client-side state.
+
+## BMS map → template mapping
+
+| BMS map     | Template path                    | Owner  |
+|-------------|----------------------------------|--------|
+| COSGN00.bms | web/auth/templates/signin.html   | RAU-39 ✓ |
+| COADM01.bms | web/admin/templates/admin.html   | RAU-39 ✓ |
+| COMEN01.bms | web/menu/templates/menu.html     | RAU-43 |
+| COACTVW.bms | web/account/templates/view.html  | RAU-38 |
+| COACTUP.bms | web/account/templates/update.html| RAU-38 |
+| COCRDSL.bms | web/card/templates/select.html   | RAU-40 |
+| COCRDLI.bms | web/card/templates/list.html     | RAU-40 |
+| COCRDUP.bms | web/card/templates/update.html   | RAU-40 |
+| COTRN00.bms | web/txn/templates/list.html      | RAU-41 |
+| COTRN01.bms | web/txn/templates/add.html       | RAU-41 |
+| COTRN02.bms | web/txn/templates/view.html      | RAU-41 |
+| COBIL00.bms | web/billing/templates/pay.html   | RAU-42 |
+| CORPT00.bms | web/report/templates/report.html | RAU-45 |
+| COUSR00.bms | web/user/templates/list.html     | RAU-39 ✓ |
+| COUSR01.bms | web/user/templates/add.html      | RAU-39 ✓ |
+| COUSR02.bms | web/user/templates/update.html   | RAU-39 ✓ |
+| COUSR03.bms | web/user/templates/delete.html   | RAU-39 ✓ |
+
+## Consequences
+
+- No JavaScript build step; the binary is self-contained.
+- Screen-flow (which CICS SEND MAP to issue) is replaced by HTTP redirects.
+- Auto-escaping in `html/template` prevents XSS by default.

--- a/docs/adr/0006-batch-orchestration.md
+++ b/docs/adr/0006-batch-orchestration.md
@@ -1,0 +1,31 @@
+# ADR 0006 — Batch orchestration: replacing JCL
+
+**Status:** Accepted (RAU-36)
+
+## Context
+
+CardDemo's batch workload is driven by JCL job streams (POSTTRAN.jcl, INTCALC.jcl, etc.).
+JCL is mainframe-specific and cannot run in a Go application.
+
+## Decision
+
+**`cmd/batch` CLI with subcommands, plus a thin YAML orchestrator.**
+
+- Each JCL step is a Go function in `internal/batch/` invoked as a `cmd/batch <subcommand>`.
+- A YAML config file (`configs/orchestrator.yaml`) declares job sequences and their step order,
+  replacing JCL EXEC and DD card sequencing. A thin orchestrator reads the YAML and runs steps
+  in order, capturing return codes.
+- No daemon or scheduler is built; external schedulers (cron, AWS Batch, Step Functions) invoke
+  `cmd/batch` subcommands directly.
+
+## Alternatives considered
+
+- Keep JCL and use a JCL interpreter: adds a heavy dependency; the programs themselves still need porting.
+- One binary per JCL job: multiplies build artifacts; a single `cmd/batch` with subcommands is simpler.
+- Embedded Go script (e.g., `gopher/script`): adds a scripting runtime for what is essentially a list of steps.
+
+## Consequences
+
+- Each batch function has a clear input (file path or DB query) and return code (0 = success, non-zero = fail).
+- Integration tests run individual batch functions with an in-memory SQLite DB (no JCL, no file system).
+- The YAML orchestrator is `configs/orchestrator.yaml.example`; production copies override it.

--- a/docs/adr/0007-decimal-arithmetic.md
+++ b/docs/adr/0007-decimal-arithmetic.md
@@ -1,0 +1,30 @@
+# ADR 0007 — Decimal arithmetic for COMP-3 and monetary fields
+
+**Status:** Accepted (RAU-36)
+
+## Context
+
+COBOL COMP-3 (packed decimal) and DISPLAY NUMERIC fields represent monetary values
+with exact decimal precision. IEEE 754 `float64` cannot represent all decimal fractions
+exactly and must never be used for money (e.g. 0.1 + 0.2 ≠ 0.3 in floating point).
+
+## Decision
+
+**`github.com/shopspring/decimal` for all monetary and COMP-3 fields.**
+
+- All domain fields representing money or count-with-scale use `decimal.Decimal`.
+- `float64` is banned for monetary values; a `golangci-lint` custom rule enforces this.
+- `internal/cobolfmt` provides `Comp3Decode` / `Comp3Encode` helpers that convert
+  between packed-decimal bytes and `decimal.Decimal`.
+
+## Alternatives considered
+
+- `math/big.Float`: arbitrary precision but no fixed-scale semantics; error-prone for monetary rounding.
+- `int64` cents: requires tracking scale separately; error-prone when mixing scales across programs.
+- `shopspring/decimal`: widely used, supports COBOL-style rounding modes (ROUND_HALF_UP), serialises cleanly to JSON and SQL.
+
+## Consequences
+
+- All SQL columns for monetary fields use `NUMERIC(15,2)` (or equivalent).
+- JSON serialisation uses `decimal.Decimal`'s `MarshalJSON` (decimal string, not float).
+- Division and rounding use `decimal.Decimal.Div(...).Round(2)` — callers must specify scale explicitly.

--- a/docs/adr/0008-logging-observability.md
+++ b/docs/adr/0008-logging-observability.md
@@ -1,0 +1,32 @@
+# ADR 0008 — Logging and observability baseline
+
+**Status:** Accepted (RAU-36)
+
+## Context
+
+The mainframe emits SMF records and CICS journal entries for observability.
+The Go port needs a structured logging baseline that is lightweight and composable.
+Deeper observability (traces, metrics) is deferred to a later issue.
+
+## Decision
+
+**`log/slog` (Go stdlib structured logger), request-scoped via `context.Context`.**
+
+- The default handler is `slog.NewJSONHandler(os.Stdout, nil)` in production,
+  `slog.NewTextHandler(os.Stderr, nil)` in development (`LOG_FORMAT=text` env var).
+- Handlers attach a request-scoped logger to `context.Context` via a middleware;
+  all log calls within a request use `slog.FromCtx(ctx)`.
+- Log levels: DEBUG (local dev), INFO (production default), WARN / ERROR for exceptions.
+- Audit events go through `internal/audit` (separate sink), not `slog`.
+
+## Alternatives considered
+
+- `zerolog`: fastest JSON logger, but adds a dependency for a feature stdlib now covers.
+- `zap`: high-performance, two APIs (sugared / typed); `slog` is simpler and sufficient.
+- `logrus`: older, reflection-based; `slog` is the stdlib successor.
+
+## Consequences
+
+- No logging dependency to manage; `slog` is in the standard library since Go 1.21.
+- Context propagation means log fields (request-ID, user-ID) appear on every line within a request.
+- Metrics and distributed traces are out of scope for the current phase.

--- a/docs/adr/0009-testing.md
+++ b/docs/adr/0009-testing.md
@@ -1,0 +1,27 @@
+# ADR 0009 — Testing strategy
+
+**Status:** Accepted (RAU-36)
+
+## Context
+
+COBOL programs are tested via batch runs and CICS terminal scripts.
+The Go port needs a testing strategy that gives fast feedback, covers the business
+logic inherited from COBOL, and validates the data-layer without a running Postgres instance.
+
+## Decision
+
+**`testing` (stdlib) + `testify/assert` + `go-cmp`; integration tests use in-memory SQLite.**
+
+- Unit tests use `testing` + `github.com/stretchr/testify/assert` for readable assertions.
+- Deep struct comparison uses `github.com/google/go-cmp/cmp` (handles unexported fields, custom comparers).
+- Integration tests that touch the repository layer spin up an in-memory `modernc.org/sqlite` DB per test
+  (no Docker, no Postgres required in CI for the base suite).
+- Golden-file tests for COBOL format conversions live in `internal/cobolfmt/testdata/`.
+- Table-driven tests are preferred for COBOL-derived logic (many input/output rows).
+- The `-race` flag is opt-in (`make test RACE=1`) because `modernc.org/sqlite` does not support `-race` under CGO-free mode; the race detector runs on non-DB test targets in CI.
+
+## Consequences
+
+- `go test ./...` passes on a clean checkout with no external services.
+- `make test` runs the full suite; `make test RACE=1` adds the race detector for non-repo packages.
+- Coverage targets: 80% line coverage for `internal/auth` and `internal/cobolfmt` at minimum.

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,8 @@ module github.com/aws-samples/aws-mainframe-modernization-carddemo
 
 go 1.26.2
 
-require golang.org/x/crypto v0.50.0
+require (
+	github.com/shopspring/decimal v1.4.0
+	golang.org/x/crypto v0.50.0
+	golang.org/x/text v0.36.0
+)

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module github.com/aws-samples/aws-mainframe-modernization-carddemo
+
+go 1.26.2
+
+require golang.org/x/crypto v0.50.0

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+golang.org/x/crypto v0.50.0 h1:zO47/JPrL6vsNkINmLoo/PH1gcxpls50DNogFvB5ZGI=
+golang.org/x/crypto v0.50.0/go.mod h1:3muZ7vA7PBCE6xgPX7nkzzjiUq87kRItoJQM1Yo8S+Q=

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,6 @@
+github.com/shopspring/decimal v1.4.0 h1:bxl37RwXBklmTi0C79JfXCEBD1cqqHt0bbgBAGFp81k=
+github.com/shopspring/decimal v1.4.0/go.mod h1:gawqmDU56v4yIKSwfBSFip1HdCCXN8/+DMd9qYNcwME=
 golang.org/x/crypto v0.50.0 h1:zO47/JPrL6vsNkINmLoo/PH1gcxpls50DNogFvB5ZGI=
 golang.org/x/crypto v0.50.0/go.mod h1:3muZ7vA7PBCE6xgPX7nkzzjiUq87kRItoJQM1Yo8S+Q=
+golang.org/x/text v0.36.0 h1:JfKh3XmcRPqZPKevfXVpI1wXPTqbkE5f7JA92a55Yxg=
+golang.org/x/text v0.36.0/go.mod h1:NIdBknypM8iqVmPiuco0Dh6P5Jcdk8lJL0CUebqK164=

--- a/internal/audit/audit.go
+++ b/internal/audit/audit.go
@@ -22,12 +22,12 @@ const (
 
 // Event is intentionally narrow: never carry password material, even hashed.
 type Event struct {
-	At      time.Time
-	Action  Action
-	Actor   string // authenticated user, "" if pre-auth
-	Target  string // user id being acted on, may equal Actor for self
-	Remote  string // remote IP / forwarded address
-	Reason  string // freeform short reason, e.g. "wrong password"
+	At     time.Time
+	Action Action
+	Actor  string // authenticated user, "" if pre-auth
+	Target string // user id being acted on, may equal Actor for self
+	Remote string // remote IP / forwarded address
+	Reason string // freeform short reason, e.g. "wrong password"
 }
 
 // Sink receives audit events. Implementations must be safe for concurrent use.

--- a/internal/audit/audit.go
+++ b/internal/audit/audit.go
@@ -1,0 +1,78 @@
+// Package audit provides a tiny structured audit log used by the auth and
+// admin-user flows. Every login attempt and every admin user mutation must
+// produce one Event so security review (RAU-46) can replay activity.
+package audit
+
+import (
+	"sync"
+	"time"
+)
+
+type Action string
+
+const (
+	ActionLoginSuccess Action = "login.success"
+	ActionLoginFailure Action = "login.failure"
+	ActionLogout       Action = "logout"
+	ActionUserCreate   Action = "user.create"
+	ActionUserUpdate   Action = "user.update"
+	ActionUserDelete   Action = "user.delete"
+	ActionAccessDenied Action = "access.denied"
+)
+
+// Event is intentionally narrow: never carry password material, even hashed.
+type Event struct {
+	At      time.Time
+	Action  Action
+	Actor   string // authenticated user, "" if pre-auth
+	Target  string // user id being acted on, may equal Actor for self
+	Remote  string // remote IP / forwarded address
+	Reason  string // freeform short reason, e.g. "wrong password"
+}
+
+// Sink receives audit events. Implementations must be safe for concurrent use.
+type Sink interface {
+	Record(Event)
+}
+
+// MemorySink keeps events in memory; suitable for tests and dev. Production
+// will swap in a Sink that writes to durable storage.
+type MemorySink struct {
+	mu     sync.Mutex
+	events []Event
+	now    func() time.Time
+}
+
+func NewMemorySink() *MemorySink {
+	return &MemorySink{now: time.Now}
+}
+
+func (s *MemorySink) Record(e Event) {
+	if e.At.IsZero() {
+		e.At = s.now()
+	}
+	s.mu.Lock()
+	s.events = append(s.events, e)
+	s.mu.Unlock()
+}
+
+func (s *MemorySink) Events() []Event {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := make([]Event, len(s.events))
+	copy(out, s.events)
+	return out
+}
+
+// CountByAction is handy for tests that assert "exactly N login.failure events".
+func (s *MemorySink) CountByAction(a Action) int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	n := 0
+	for _, e := range s.events {
+		if e.Action == a {
+			n++
+		}
+	}
+	return n
+}

--- a/internal/audit/doc.go
+++ b/internal/audit/doc.go
@@ -1,0 +1,15 @@
+// Package audit records security-relevant events for CardDemo.
+//
+// It replaces the SMF (System Management Facilities) audit trail that RACF and
+// CICS write implicitly on the mainframe. Events are written to an append-only
+// sink; the Sink interface allows swapping in-memory (tests) and database-backed
+// (production) implementations without changing callers.
+//
+// COBOL programs that emit auditable events:
+//
+//	COSGN00C.cbl  — sign-on / sign-off events
+//	COADM01C.cbl  — admin user create/update/delete events
+//	COUSR01C.cbl  — user create events
+//	COUSR02C.cbl  — user update events
+//	COUSR03C.cbl  — user delete events
+package audit

--- a/internal/auth/csrf.go
+++ b/internal/auth/csrf.go
@@ -1,0 +1,41 @@
+package auth
+
+import (
+	"crypto/subtle"
+	"net/http"
+	"time"
+)
+
+// NewCSRFToken returns a fresh random token suitable for double-submit.
+func NewCSRFToken() (string, error) {
+	return randomToken()
+}
+
+// SetPreLoginCSRFCookie writes a pre-login CSRF cookie under the same name as
+// the session-bound cookie. This way the CSRFProtect middleware enforces
+// double-submit on POST /login without a separate code path, and the cookie is
+// transparently overwritten by the session-bound value at login time.
+//
+// It is intentionally NOT HttpOnly so a JS-driven login form can mirror the
+// value into the hidden field.
+func SetPreLoginCSRFCookie(w http.ResponseWriter, token string, opts CookieOptions) {
+	http.SetCookie(w, &http.Cookie{
+		Name:     CSRFCookieName,
+		Value:    token,
+		Path:     opts.Path,
+		Domain:   opts.Domain,
+		Expires:  time.Now().Add(15 * time.Minute),
+		MaxAge:   int((15 * time.Minute).Seconds()),
+		Secure:   opts.Secure,
+		HttpOnly: false,
+		SameSite: opts.SameSite,
+	})
+}
+
+// ConstantTimeEqual is a length-aware constant-time string compare.
+func ConstantTimeEqual(a, b string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	return subtle.ConstantTimeCompare([]byte(a), []byte(b)) == 1
+}

--- a/internal/auth/doc.go
+++ b/internal/auth/doc.go
@@ -1,0 +1,12 @@
+// Package auth implements CardDemo authentication and session management.
+//
+// It replaces RACF sign-on (COSGN00C.cbl) and the CICS security interface with
+// a Go HTTP-session stack: bcrypt password hashing, CSRF protection, rate
+// limiting, and an in-memory (stub) / database-backed session store.
+//
+// COBOL program → auth component mapping:
+//
+//	COSGN00C.cbl  → Service.SignIn / Service.SignOut
+//	COADM01C.cbl  → admin user CRUD (Service.Create/Update/Delete/List via RAU-39)
+//	CSUSR01Y.cpy  → domain.UserSec (the security-record struct)
+package auth

--- a/internal/auth/middleware.go
+++ b/internal/auth/middleware.go
@@ -1,0 +1,174 @@
+package auth
+
+import (
+	"context"
+	"crypto/subtle"
+	"errors"
+	"net"
+	"net/http"
+	"strings"
+
+	"github.com/aws-samples/aws-mainframe-modernization-carddemo/internal/audit"
+	"github.com/aws-samples/aws-mainframe-modernization-carddemo/internal/domain"
+)
+
+type ctxKey int
+
+const sessionCtxKey ctxKey = 1
+
+// SessionFromContext returns the authenticated session, or false if the
+// request is anonymous.
+func SessionFromContext(ctx context.Context) (Session, bool) {
+	s, ok := ctx.Value(sessionCtxKey).(Session)
+	return s, ok
+}
+
+func withSession(ctx context.Context, s Session) context.Context {
+	return context.WithValue(ctx, sessionCtxKey, s)
+}
+
+// ClientIP extracts a best-effort remote IP. Trusts X-Forwarded-For only when
+// the caller wired the middleware behind a proxy that sets it; otherwise we
+// fall back to RemoteAddr.
+func ClientIP(r *http.Request) string {
+	if xf := r.Header.Get("X-Forwarded-For"); xf != "" {
+		// Take the first entry — leftmost is the original client.
+		for i := 0; i < len(xf); i++ {
+			if xf[i] == ',' {
+				return xf[:i]
+			}
+		}
+		return xf
+	}
+	host, _, err := net.SplitHostPort(r.RemoteAddr)
+	if err != nil {
+		return r.RemoteAddr
+	}
+	return host
+}
+
+// LoadSession is middleware that, if a valid session cookie is present,
+// attaches the Session to the request context. It does NOT enforce auth — use
+// RequireUser / RequireAdmin for that.
+func LoadSession(store SessionStore) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			c, err := r.Cookie(SessionCookieName)
+			if err == nil && c.Value != "" {
+				sess, err := store.Get(r.Context(), c.Value)
+				if err == nil {
+					r = r.WithContext(withSession(r.Context(), sess))
+				}
+			}
+			next.ServeHTTP(w, r)
+		})
+	}
+}
+
+// RequireUser forces the request to carry a valid session. Anonymous requests
+// get 401 (API) or a 303 redirect to /login (browser).
+func RequireUser(loginPath string) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if _, ok := SessionFromContext(r.Context()); !ok {
+				redirectOrUnauthorized(w, r, loginPath)
+				return
+			}
+			next.ServeHTTP(w, r)
+		})
+	}
+}
+
+// RequireAdmin forces the session's UserType to be ADMIN. Non-admin users get
+// 403 + an audit event so we can spot privilege-probing.
+func RequireAdmin(sink audit.Sink, loginPath string) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			sess, ok := SessionFromContext(r.Context())
+			if !ok {
+				redirectOrUnauthorized(w, r, loginPath)
+				return
+			}
+			if sess.UserType != domain.UserTypeAdmin {
+				if sink != nil {
+					sink.Record(audit.Event{
+						Action: audit.ActionAccessDenied,
+						Actor:  sess.UserID,
+						Target: r.URL.Path,
+						Remote: ClientIP(r),
+						Reason: "non-admin attempted admin action",
+					})
+				}
+				http.Error(w, "forbidden", http.StatusForbidden)
+				return
+			}
+			next.ServeHTTP(w, r)
+		})
+	}
+}
+
+func redirectOrUnauthorized(w http.ResponseWriter, r *http.Request, loginPath string) {
+	if wantsHTML(r) && loginPath != "" {
+		http.Redirect(w, r, loginPath, http.StatusSeeOther)
+		return
+	}
+	http.Error(w, "unauthorized", http.StatusUnauthorized)
+}
+
+func wantsHTML(r *http.Request) bool {
+	a := r.Header.Get("Accept")
+	return a == "" || strings.Contains(strings.ToLower(a), "text/html")
+}
+
+// CSRFProtect is middleware for state-changing requests (POST/PUT/DELETE/PATCH).
+// It enforces double-submit: the token in the CSRFCookieName cookie must equal
+// the token in the form field or X-CSRF-Token header. Constant-time compare.
+//
+// Safe methods (GET/HEAD/OPTIONS) pass through untouched.
+func CSRFProtect() func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if isSafeMethod(r.Method) {
+				next.ServeHTTP(w, r)
+				return
+			}
+			cookie, err := r.Cookie(CSRFCookieName)
+			if err != nil || cookie.Value == "" {
+				http.Error(w, "missing csrf token", http.StatusForbidden)
+				return
+			}
+			submitted := r.Header.Get(CSRFHeader)
+			if submitted == "" {
+				// Parse form lazily; ignore parse errors (handler may have a richer parser).
+				_ = r.ParseForm()
+				submitted = r.PostFormValue(CSRFFormField)
+			}
+			if submitted == "" {
+				http.Error(w, "missing csrf token", http.StatusForbidden)
+				return
+			}
+			if subtle.ConstantTimeCompare([]byte(submitted), []byte(cookie.Value)) != 1 {
+				http.Error(w, "invalid csrf token", http.StatusForbidden)
+				return
+			}
+			// Belt-and-braces: if there is a session, the cookie token must match the session's token too.
+			if sess, ok := SessionFromContext(r.Context()); ok {
+				if subtle.ConstantTimeCompare([]byte(cookie.Value), []byte(sess.CSRFToken)) != 1 {
+					http.Error(w, "invalid csrf token", http.StatusForbidden)
+					return
+				}
+			}
+			next.ServeHTTP(w, r)
+		})
+	}
+}
+
+func isSafeMethod(m string) bool {
+	return m == http.MethodGet || m == http.MethodHead || m == http.MethodOptions
+}
+
+// Common errors callers may want to detect.
+var (
+	ErrUnauthenticated = errors.New("unauthenticated")
+	ErrForbidden       = errors.New("forbidden")
+)

--- a/internal/auth/password.go
+++ b/internal/auth/password.go
@@ -1,0 +1,40 @@
+package auth
+
+import (
+	"errors"
+
+	"golang.org/x/crypto/bcrypt"
+)
+
+// DefaultBcryptCost is bcrypt's default (10). Tests may pass a lower cost via
+// HashPasswordCost to keep brute-force loops fast; production callers should
+// always use HashPassword.
+const DefaultBcryptCost = bcrypt.DefaultCost
+
+// ErrPasswordMismatch signals a mismatched password without leaking whether
+// the user existed. Callers MUST collapse "user not found" into the same
+// error code path before logging.
+var ErrPasswordMismatch = errors.New("invalid credentials")
+
+func HashPassword(plain string) (string, error) {
+	return HashPasswordCost(plain, DefaultBcryptCost)
+}
+
+func HashPasswordCost(plain string, cost int) (string, error) {
+	h, err := bcrypt.GenerateFromPassword([]byte(plain), cost)
+	if err != nil {
+		return "", err
+	}
+	return string(h), nil
+}
+
+// VerifyPassword compares a bcrypt hash to a plaintext attempt in constant time
+// (bcrypt.CompareHashAndPassword does the constant-time compare internally).
+// Returns ErrPasswordMismatch on any mismatch so call sites can branch on a
+// single sentinel.
+func VerifyPassword(hash, plain string) error {
+	if err := bcrypt.CompareHashAndPassword([]byte(hash), []byte(plain)); err != nil {
+		return ErrPasswordMismatch
+	}
+	return nil
+}

--- a/internal/auth/password_test.go
+++ b/internal/auth/password_test.go
@@ -1,0 +1,31 @@
+package auth
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestHashAndVerifyPassword(t *testing.T) {
+	hash, err := HashPasswordCost("PASSWORD", 4)
+	if err != nil {
+		t.Fatalf("hash: %v", err)
+	}
+	if hash == "PASSWORD" || strings.Contains(hash, "PASSWORD") {
+		t.Fatal("bcrypt hash must not contain plaintext")
+	}
+	if err := VerifyPassword(hash, "PASSWORD"); err != nil {
+		t.Fatalf("verify success: %v", err)
+	}
+	if err := VerifyPassword(hash, "wrong"); !errors.Is(err, ErrPasswordMismatch) {
+		t.Fatalf("expected mismatch sentinel, got %v", err)
+	}
+}
+
+func TestVerifyPasswordCollapsesAllErrorsToMismatch(t *testing.T) {
+	// A garbage hash must still produce ErrPasswordMismatch (no leakage of the
+	// underlying bcrypt-format error to upstream).
+	if err := VerifyPassword("not-a-bcrypt-hash", "anything"); !errors.Is(err, ErrPasswordMismatch) {
+		t.Fatalf("expected ErrPasswordMismatch, got %v", err)
+	}
+}

--- a/internal/auth/ratelimit.go
+++ b/internal/auth/ratelimit.go
@@ -18,11 +18,11 @@ import (
 // Reset(key) to clear the user counter so a legitimate user is not locked out
 // after their own typo.
 type RateLimiter struct {
-	mu       sync.Mutex
-	buckets  map[string]*bucket
-	max      int
-	window   time.Duration
-	now      func() time.Time
+	mu      sync.Mutex
+	buckets map[string]*bucket
+	max     int
+	window  time.Duration
+	now     func() time.Time
 }
 
 type bucket struct {

--- a/internal/auth/ratelimit.go
+++ b/internal/auth/ratelimit.go
@@ -1,0 +1,86 @@
+package auth
+
+import (
+	"sync"
+	"time"
+)
+
+// RateLimiter is a fixed-window counter keyed by (key) — typically "ip:1.2.3.4"
+// or "user:ADMIN001". A failed login records both an IP key and a username key
+// so attackers cannot hide behind either rotation alone.
+//
+// Two cohorts are tracked separately because they need different policies:
+// per-IP is broad (catches credential stuffing), per-user is tight (catches
+// targeted brute force). The handler increments both on failure.
+//
+// On Allow: if the key is currently over budget (>= max attempts inside the
+// window), returns false and a Retry-After hint. Successful logins should call
+// Reset(key) to clear the user counter so a legitimate user is not locked out
+// after their own typo.
+type RateLimiter struct {
+	mu       sync.Mutex
+	buckets  map[string]*bucket
+	max      int
+	window   time.Duration
+	now      func() time.Time
+}
+
+type bucket struct {
+	count       int
+	windowStart time.Time
+}
+
+func NewRateLimiter(max int, window time.Duration) *RateLimiter {
+	return &RateLimiter{
+		buckets: make(map[string]*bucket),
+		max:     max,
+		window:  window,
+		now:     time.Now,
+	}
+}
+
+// Allow records a hit and returns false if the key is over budget. The second
+// return is the time remaining in the current window (only meaningful on a
+// false return).
+func (r *RateLimiter) Allow(key string) (bool, time.Duration) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	now := r.now()
+	b, ok := r.buckets[key]
+	if !ok || now.Sub(b.windowStart) >= r.window {
+		r.buckets[key] = &bucket{count: 1, windowStart: now}
+		return true, 0
+	}
+	if b.count >= r.max {
+		return false, r.window - now.Sub(b.windowStart)
+	}
+	b.count++
+	return true, 0
+}
+
+// Peek reports whether the key is currently over budget without recording a
+// hit. Used to short-circuit a request before doing any work (and before the
+// password compare, so we don't burn bcrypt cycles on a locked-out attacker).
+func (r *RateLimiter) Peek(key string) (bool, time.Duration) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	b, ok := r.buckets[key]
+	if !ok {
+		return true, 0
+	}
+	now := r.now()
+	if now.Sub(b.windowStart) >= r.window {
+		return true, 0
+	}
+	if b.count >= r.max {
+		return false, r.window - now.Sub(b.windowStart)
+	}
+	return true, 0
+}
+
+// Reset clears the counter for a key, e.g. after a successful login.
+func (r *RateLimiter) Reset(key string) {
+	r.mu.Lock()
+	delete(r.buckets, key)
+	r.mu.Unlock()
+}

--- a/internal/auth/ratelimit_test.go
+++ b/internal/auth/ratelimit_test.go
@@ -1,0 +1,70 @@
+package auth
+
+import (
+	"testing"
+	"time"
+)
+
+func TestRateLimiterAllowsUpToMax(t *testing.T) {
+	rl := NewRateLimiter(3, time.Minute)
+	for i := 0; i < 3; i++ {
+		ok, _ := rl.Allow("k")
+		if !ok {
+			t.Fatalf("attempt %d: expected allow", i)
+		}
+	}
+	ok, retry := rl.Allow("k")
+	if ok {
+		t.Fatal("4th attempt should be denied")
+	}
+	if retry <= 0 {
+		t.Fatalf("expected positive retry-after, got %v", retry)
+	}
+}
+
+func TestRateLimiterPeekDoesNotConsume(t *testing.T) {
+	rl := NewRateLimiter(2, time.Minute)
+	rl.Allow("k")
+	for i := 0; i < 5; i++ {
+		ok, _ := rl.Peek("k")
+		if !ok {
+			t.Fatal("peek should not exhaust the budget")
+		}
+	}
+	ok, _ := rl.Allow("k")
+	if !ok {
+		t.Fatal("second Allow after Peeks should still be allowed")
+	}
+	ok, _ = rl.Allow("k")
+	if ok {
+		t.Fatal("third Allow should be denied")
+	}
+}
+
+func TestRateLimiterWindowExpiry(t *testing.T) {
+	rl := NewRateLimiter(2, time.Minute)
+	now := time.Unix(0, 0)
+	rl.now = func() time.Time { return now }
+
+	rl.Allow("k")
+	rl.Allow("k")
+	if ok, _ := rl.Allow("k"); ok {
+		t.Fatal("expected denial inside window")
+	}
+	now = now.Add(2 * time.Minute)
+	if ok, _ := rl.Allow("k"); !ok {
+		t.Fatal("expected allow after window expiry")
+	}
+}
+
+func TestRateLimiterReset(t *testing.T) {
+	rl := NewRateLimiter(1, time.Minute)
+	rl.Allow("k")
+	if ok, _ := rl.Allow("k"); ok {
+		t.Fatal("expected denial before reset")
+	}
+	rl.Reset("k")
+	if ok, _ := rl.Allow("k"); !ok {
+		t.Fatal("expected allow after reset")
+	}
+}

--- a/internal/auth/seed.go
+++ b/internal/auth/seed.go
@@ -1,0 +1,64 @@
+package auth
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/aws-samples/aws-mainframe-modernization-carddemo/internal/domain"
+	"github.com/aws-samples/aws-mainframe-modernization-carddemo/internal/repo"
+)
+
+// SeedFixture is a single legacy-style record in the seed list. Password is
+// the plaintext from the legacy fixtures; SeedDefaultUsers replaces it with a
+// bcrypt hash before writing to the repo.
+type SeedFixture struct {
+	UserID    string
+	FirstName string
+	LastName  string
+	Password  string
+	Type      domain.UserType
+}
+
+// DefaultFixtures mirror the legacy seed:
+//
+//	ADMIN001 / PASSWORD  (admin)
+//	USER0001 / PASSWORD  (regular user)
+//
+// These are the credentials documented in COSGN00C.cbl test runs. The seed
+// step replaces the cleartext PIC X(08) password with a bcrypt hash so no
+// cleartext credential is ever persisted.
+func DefaultFixtures() []SeedFixture {
+	return []SeedFixture{
+		{UserID: "ADMIN001", FirstName: "Admin", LastName: "User", Password: "PASSWORD", Type: domain.UserTypeAdmin},
+		{UserID: "USER0001", FirstName: "Regular", LastName: "User", Password: "PASSWORD", Type: domain.UserTypeUser},
+	}
+}
+
+// SeedDefaultUsers inserts the default fixtures into the given repo, hashing
+// each password with bcrypt at the supplied cost. Idempotent: an existing
+// user_id is skipped (not overwritten).
+func SeedDefaultUsers(ctx context.Context, r repo.UserSecRepo, cost int) error {
+	if cost == 0 {
+		cost = DefaultBcryptCost
+	}
+	for _, f := range DefaultFixtures() {
+		if _, err := r.Get(ctx, f.UserID); err == nil {
+			continue
+		}
+		hash, err := HashPasswordCost(f.Password, cost)
+		if err != nil {
+			return fmt.Errorf("hash %s: %w", f.UserID, err)
+		}
+		u := domain.UserSec{
+			UserID:    domain.NormalizeUserID(f.UserID),
+			FirstName: f.FirstName,
+			LastName:  f.LastName,
+			PwdHash:   hash,
+			Type:      f.Type,
+		}
+		if err := r.Create(ctx, u); err != nil {
+			return fmt.Errorf("create %s: %w", f.UserID, err)
+		}
+	}
+	return nil
+}

--- a/internal/auth/service.go
+++ b/internal/auth/service.go
@@ -1,0 +1,191 @@
+package auth
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"time"
+
+	"github.com/aws-samples/aws-mainframe-modernization-carddemo/internal/audit"
+	"github.com/aws-samples/aws-mainframe-modernization-carddemo/internal/domain"
+	"github.com/aws-samples/aws-mainframe-modernization-carddemo/internal/repo"
+)
+
+// DefaultSessionTTL is the lifetime of a fresh session. Production may want
+// shorter for admin sessions; we keep one knob for simplicity.
+const DefaultSessionTTL = 8 * time.Hour
+
+// DefaultLoginAttemptsPerWindow / DefaultLoginWindow are the rate-limit
+// defaults. The numbers are deliberately conservative — five tries inside a
+// fifteen-minute window per IP and per user. The handler trips on either.
+const (
+	DefaultLoginAttemptsPerWindow = 5
+	DefaultLoginWindow            = 15 * time.Minute
+)
+
+// ErrRateLimited is returned when an IP or username is over budget.
+var ErrRateLimited = errors.New("too many login attempts")
+
+// Service is the authn/authz layer over a UserSec repository. Handlers depend
+// on this; tests use it directly without going through HTTP.
+type Service struct {
+	Users          repo.UserSecRepo
+	Sessions       SessionStore
+	Audit          audit.Sink
+	IPLimiter      *RateLimiter
+	UserLimiter    *RateLimiter
+	SessionTTL     time.Duration
+}
+
+// NewService wires sensible defaults around a repo + store.
+func NewService(users repo.UserSecRepo, store SessionStore, sink audit.Sink) *Service {
+	return &Service{
+		Users:       users,
+		Sessions:    store,
+		Audit:       sink,
+		IPLimiter:   NewRateLimiter(DefaultLoginAttemptsPerWindow*4, DefaultLoginWindow),
+		UserLimiter: NewRateLimiter(DefaultLoginAttemptsPerWindow, DefaultLoginWindow),
+		SessionTTL:  DefaultSessionTTL,
+	}
+}
+
+// Login validates credentials, applies per-IP and per-user rate limiting,
+// audits the attempt, and on success returns a fresh server-side session.
+//
+// On any failure the audit Reason is intentionally generic so the response
+// path can return a non-leaky message to the client.
+func (s *Service) Login(ctx context.Context, userID, password, remote string) (Session, error) {
+	id := domain.NormalizeUserID(userID)
+	ipKey := "ip:" + remote
+	userKey := "user:" + id
+
+	// Pre-check both limiters before doing any work — bcrypt is expensive and
+	// we don't want an attacker to keep us busy after they're already locked.
+	if ok, _ := s.IPLimiter.Peek(ipKey); !ok {
+		s.audit(audit.Event{Action: audit.ActionLoginFailure, Target: id, Remote: remote, Reason: "ip rate limited"})
+		return Session{}, ErrRateLimited
+	}
+	if ok, _ := s.UserLimiter.Peek(userKey); !ok {
+		s.audit(audit.Event{Action: audit.ActionLoginFailure, Target: id, Remote: remote, Reason: "user rate limited"})
+		return Session{}, ErrRateLimited
+	}
+
+	user, err := s.Users.Get(ctx, id)
+	if err != nil {
+		s.recordFailure(ipKey, userKey)
+		s.audit(audit.Event{Action: audit.ActionLoginFailure, Target: id, Remote: remote, Reason: "unknown user"})
+		return Session{}, ErrPasswordMismatch
+	}
+
+	if err := VerifyPassword(user.PwdHash, password); err != nil {
+		s.recordFailure(ipKey, userKey)
+		s.audit(audit.Event{Action: audit.ActionLoginFailure, Target: id, Remote: remote, Reason: "wrong password"})
+		return Session{}, ErrPasswordMismatch
+	}
+
+	// Success: clear the user counter so a single typo doesn't compound, but
+	// leave the IP counter alone — high IP volume across users is itself
+	// suspicious.
+	s.UserLimiter.Reset(userKey)
+
+	sess, err := s.Sessions.New(ctx, user.UserID, user.Type, s.SessionTTL)
+	if err != nil {
+		s.audit(audit.Event{Action: audit.ActionLoginFailure, Target: id, Remote: remote, Reason: "session create failed"})
+		return Session{}, err
+	}
+	s.audit(audit.Event{Action: audit.ActionLoginSuccess, Actor: user.UserID, Target: user.UserID, Remote: remote})
+	return sess, nil
+}
+
+func (s *Service) Logout(ctx context.Context, sess Session, remote string) error {
+	err := s.Sessions.Delete(ctx, sess.ID)
+	s.audit(audit.Event{Action: audit.ActionLogout, Actor: sess.UserID, Target: sess.UserID, Remote: remote})
+	return err
+}
+
+func (s *Service) recordFailure(ipKey, userKey string) {
+	s.IPLimiter.Allow(ipKey)
+	s.UserLimiter.Allow(userKey)
+}
+
+func (s *Service) audit(e audit.Event) {
+	if s.Audit != nil {
+		s.Audit.Record(e)
+	}
+}
+
+// CreateUser hashes the plaintext password and inserts a new UserSec record.
+// Returns ErrConflict from repo if the id is taken.
+func (s *Service) CreateUser(ctx context.Context, actor, userID, first, last, password string, t domain.UserType, remote string) error {
+	if err := domain.ValidateUserInput(userID, first, last, t); err != nil {
+		return err
+	}
+	if err := domain.ValidatePassword(password); err != nil {
+		return err
+	}
+	hash, err := HashPassword(password)
+	if err != nil {
+		return err
+	}
+	id := domain.NormalizeUserID(userID)
+	u := domain.UserSec{
+		UserID:    id,
+		FirstName: strings.TrimSpace(first),
+		LastName:  strings.TrimSpace(last),
+		PwdHash:   hash,
+		Type:      t,
+	}
+	if err := s.Users.Create(ctx, u); err != nil {
+		return err
+	}
+	s.audit(audit.Event{Action: audit.ActionUserCreate, Actor: actor, Target: id, Remote: remote})
+	return nil
+}
+
+// UpdateUser updates first/last/type and, if newPassword is non-empty, the
+// hash. It never touches an existing hash unless explicitly asked.
+func (s *Service) UpdateUser(ctx context.Context, actor, userID, first, last, newPassword string, t domain.UserType, remote string) error {
+	if err := domain.ValidateUserInput(userID, first, last, t); err != nil {
+		return err
+	}
+	id := domain.NormalizeUserID(userID)
+	existing, err := s.Users.Get(ctx, id)
+	if err != nil {
+		return err
+	}
+	existing.FirstName = strings.TrimSpace(first)
+	existing.LastName = strings.TrimSpace(last)
+	existing.Type = t
+	if newPassword != "" {
+		if err := domain.ValidatePassword(newPassword); err != nil {
+			return err
+		}
+		hash, err := HashPassword(newPassword)
+		if err != nil {
+			return err
+		}
+		existing.PwdHash = hash
+	}
+	if err := s.Users.Update(ctx, existing); err != nil {
+		return err
+	}
+	s.audit(audit.Event{Action: audit.ActionUserUpdate, Actor: actor, Target: id, Remote: remote})
+	return nil
+}
+
+func (s *Service) DeleteUser(ctx context.Context, actor, userID, remote string) error {
+	id := domain.NormalizeUserID(userID)
+	if err := s.Users.Delete(ctx, id); err != nil {
+		return err
+	}
+	s.audit(audit.Event{Action: audit.ActionUserDelete, Actor: actor, Target: id, Remote: remote})
+	return nil
+}
+
+func (s *Service) ListUsers(ctx context.Context) ([]domain.UserSec, error) {
+	return s.Users.List(ctx)
+}
+
+func (s *Service) GetUser(ctx context.Context, userID string) (domain.UserSec, error) {
+	return s.Users.Get(ctx, userID)
+}

--- a/internal/auth/service.go
+++ b/internal/auth/service.go
@@ -29,12 +29,12 @@ var ErrRateLimited = errors.New("too many login attempts")
 // Service is the authn/authz layer over a UserSec repository. Handlers depend
 // on this; tests use it directly without going through HTTP.
 type Service struct {
-	Users          repo.UserSecRepo
-	Sessions       SessionStore
-	Audit          audit.Sink
-	IPLimiter      *RateLimiter
-	UserLimiter    *RateLimiter
-	SessionTTL     time.Duration
+	Users       repo.UserSecRepo
+	Sessions    SessionStore
+	Audit       audit.Sink
+	IPLimiter   *RateLimiter
+	UserLimiter *RateLimiter
+	SessionTTL  time.Duration
 }
 
 // NewService wires sensible defaults around a repo + store.

--- a/internal/auth/service_test.go
+++ b/internal/auth/service_test.go
@@ -1,0 +1,193 @@
+package auth
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/aws-samples/aws-mainframe-modernization-carddemo/internal/audit"
+	"github.com/aws-samples/aws-mainframe-modernization-carddemo/internal/domain"
+	"github.com/aws-samples/aws-mainframe-modernization-carddemo/internal/repo"
+)
+
+func newTestService(t *testing.T) (*Service, *audit.MemorySink, *repo.InMemoryUserSec) {
+	t.Helper()
+	users := repo.NewInMemoryUserSec()
+	sink := audit.NewMemorySink()
+	store := NewMemorySessionStore()
+	svc := NewService(users, store, sink)
+	// Tighten the windows so per-test waits are short, and use bcrypt cost 4
+	// to keep tests fast.
+	svc.UserLimiter = NewRateLimiter(3, time.Minute)
+	svc.IPLimiter = NewRateLimiter(20, time.Minute)
+	if err := SeedDefaultUsers(context.Background(), users, 4); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	return svc, sink, users
+}
+
+func TestLoginSuccessAndAudit(t *testing.T) {
+	svc, sink, _ := newTestService(t)
+	sess, err := svc.Login(context.Background(), "ADMIN001", "PASSWORD", "1.2.3.4")
+	if err != nil {
+		t.Fatalf("login: %v", err)
+	}
+	if sess.UserID != "ADMIN001" || !sess.IsAdmin() {
+		t.Fatalf("unexpected session: %+v", sess)
+	}
+	if got := sink.CountByAction(audit.ActionLoginSuccess); got != 1 {
+		t.Fatalf("expected 1 success audit, got %d", got)
+	}
+}
+
+func TestLoginUserCaseInsensitive(t *testing.T) {
+	svc, _, _ := newTestService(t)
+	sess, err := svc.Login(context.Background(), "  admin001  ", "PASSWORD", "1.2.3.4")
+	if err != nil {
+		t.Fatalf("login: %v", err)
+	}
+	if sess.UserID != "ADMIN001" {
+		t.Fatalf("expected normalized ADMIN001, got %q", sess.UserID)
+	}
+}
+
+func TestLoginWrongPasswordDoesNotLeakUserExistence(t *testing.T) {
+	svc, sink, _ := newTestService(t)
+	_, err1 := svc.Login(context.Background(), "ADMIN001", "wrong", "1.2.3.4")
+	_, err2 := svc.Login(context.Background(), "NOSUCH", "anything", "1.2.3.4")
+	if !errors.Is(err1, ErrPasswordMismatch) || !errors.Is(err2, ErrPasswordMismatch) {
+		t.Fatalf("both should return ErrPasswordMismatch, got %v / %v", err1, err2)
+	}
+	// The audit log carries Reason which differentiates the two for ops, but
+	// the public error must be identical.
+	if got := sink.CountByAction(audit.ActionLoginFailure); got != 2 {
+		t.Fatalf("expected 2 failure audits, got %d", got)
+	}
+}
+
+// TestBruteForceRateLimit is the acceptance-criteria test from RAU-39.
+//
+// Scenario: an attacker hammers ADMIN001 with bad passwords from one IP. After
+// the per-user limit (3) is exhausted, even the *correct* password must be
+// rejected with ErrRateLimited. After the window passes, login succeeds again.
+func TestBruteForceRateLimit(t *testing.T) {
+	svc, sink, _ := newTestService(t)
+
+	// Pin time so we can advance the rate-limit window deterministically.
+	now := time.Unix(1_700_000_000, 0)
+	svc.UserLimiter.now = func() time.Time { return now }
+	svc.IPLimiter.now = func() time.Time { return now }
+
+	for i := 0; i < 3; i++ {
+		_, err := svc.Login(context.Background(), "ADMIN001", "wrong", "1.2.3.4")
+		if !errors.Is(err, ErrPasswordMismatch) {
+			t.Fatalf("attempt %d: expected ErrPasswordMismatch, got %v", i, err)
+		}
+	}
+
+	// The 4th attempt — even with the correct password — must be locked out.
+	_, err := svc.Login(context.Background(), "ADMIN001", "PASSWORD", "1.2.3.4")
+	if !errors.Is(err, ErrRateLimited) {
+		t.Fatalf("expected ErrRateLimited after 3 failures, got %v", err)
+	}
+
+	// Audit must have recorded the block, not a successful login.
+	if got := sink.CountByAction(audit.ActionLoginSuccess); got != 0 {
+		t.Fatalf("brute-force lockout must not produce a success audit, got %d", got)
+	}
+	if got := sink.CountByAction(audit.ActionLoginFailure); got < 4 {
+		t.Fatalf("expected at least 4 failure audits, got %d", got)
+	}
+	// At least one of the failure events must reference the rate-limit reason.
+	sawRL := false
+	for _, e := range sink.Events() {
+		if e.Action == audit.ActionLoginFailure && strings.Contains(e.Reason, "rate limited") {
+			sawRL = true
+			break
+		}
+	}
+	if !sawRL {
+		t.Fatal("expected an audit event with reason mentioning rate limit")
+	}
+
+	// Advance past the window — now the legitimate user can sign in.
+	now = now.Add(2 * time.Minute)
+	sess, err := svc.Login(context.Background(), "ADMIN001", "PASSWORD", "1.2.3.4")
+	if err != nil {
+		t.Fatalf("expected login to succeed after window expiry, got %v", err)
+	}
+	if !sess.IsAdmin() {
+		t.Fatalf("expected admin session, got %+v", sess)
+	}
+}
+
+func TestSuccessfulLoginResetsUserCounter(t *testing.T) {
+	svc, _, _ := newTestService(t)
+	for i := 0; i < 2; i++ {
+		_, _ = svc.Login(context.Background(), "ADMIN001", "wrong", "1.2.3.4")
+	}
+	// Below the threshold — correct password succeeds.
+	if _, err := svc.Login(context.Background(), "ADMIN001", "PASSWORD", "1.2.3.4"); err != nil {
+		t.Fatalf("login: %v", err)
+	}
+	// Counter should be reset; another 2 failures must not lock out.
+	for i := 0; i < 2; i++ {
+		_, err := svc.Login(context.Background(), "ADMIN001", "wrong", "1.2.3.4")
+		if errors.Is(err, ErrRateLimited) {
+			t.Fatalf("attempt %d should not be rate limited after success reset", i)
+		}
+	}
+}
+
+func TestCreateUserHashesPassword(t *testing.T) {
+	svc, _, users := newTestService(t)
+	if err := svc.CreateUser(context.Background(), "ADMIN001", "OPERATOR", "Op", "Erator", "secret", domain.UserTypeUser, "1.2.3.4"); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	u, err := users.Get(context.Background(), "OPERATOR")
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if u.PwdHash == "secret" || strings.Contains(u.PwdHash, "secret") {
+		t.Fatal("stored password must be a bcrypt hash, not cleartext")
+	}
+	if err := VerifyPassword(u.PwdHash, "secret"); err != nil {
+		t.Fatalf("hash should verify: %v", err)
+	}
+}
+
+func TestUpdateUserKeepsHashWhenPasswordBlank(t *testing.T) {
+	svc, _, users := newTestService(t)
+	before, _ := users.Get(context.Background(), "USER0001")
+	if err := svc.UpdateUser(context.Background(), "ADMIN001", "USER0001", "Reg", "User", "", domain.UserTypeUser, "1.2.3.4"); err != nil {
+		t.Fatalf("update: %v", err)
+	}
+	after, _ := users.Get(context.Background(), "USER0001")
+	if before.PwdHash != after.PwdHash {
+		t.Fatal("blank password must not rotate the hash")
+	}
+	if after.FirstName != "Reg" || after.LastName != "User" {
+		t.Fatalf("name fields not updated: %+v", after)
+	}
+}
+
+func TestSeedIsIdempotent(t *testing.T) {
+	users := repo.NewInMemoryUserSec()
+	if err := SeedDefaultUsers(context.Background(), users, 4); err != nil {
+		t.Fatalf("seed1: %v", err)
+	}
+	if err := SeedDefaultUsers(context.Background(), users, 4); err != nil {
+		t.Fatalf("seed2: %v", err)
+	}
+	all, _ := users.List(context.Background())
+	if len(all) != 2 {
+		t.Fatalf("expected 2 seeded users, got %d", len(all))
+	}
+	for _, u := range all {
+		if u.PwdHash == "PASSWORD" || strings.Contains(u.PwdHash, "PASSWORD") {
+			t.Fatalf("seeded password for %s must be hashed, got %q", u.UserID, u.PwdHash)
+		}
+	}
+}

--- a/internal/auth/session.go
+++ b/internal/auth/session.go
@@ -1,0 +1,189 @@
+package auth
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/base64"
+	"errors"
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/aws-samples/aws-mainframe-modernization-carddemo/internal/domain"
+)
+
+// SessionCookieName is the cookie that carries the opaque session id. The id
+// is server-side only; the cookie holds nothing else (no claims, no JWT).
+const SessionCookieName = "carddemo_sid"
+
+// CSRFCookieName is the cookie that carries the CSRF token for double-submit.
+// The same value also appears in a hidden form field; the middleware compares
+// the two in constant time.
+const CSRFCookieName = "carddemo_csrf"
+
+// CSRFFormField / CSRFHeader are the input names checked on state-changing
+// requests. Either may carry the token.
+const (
+	CSRFFormField = "csrf_token"
+	CSRFHeader    = "X-CSRF-Token"
+)
+
+// Session is a server-side record. The cookie value is just the opaque ID.
+type Session struct {
+	ID        string
+	UserID    string
+	UserType  domain.UserType
+	CSRFToken string
+	CreatedAt time.Time
+	ExpiresAt time.Time
+}
+
+func (s Session) IsAdmin() bool { return s.UserType == domain.UserTypeAdmin }
+
+// SessionStore is the interface for the server-side session table. Production
+// will back this with Redis or similar; the in-memory impl is fine for dev and
+// tests.
+type SessionStore interface {
+	New(ctx context.Context, userID string, t domain.UserType, ttl time.Duration) (Session, error)
+	Get(ctx context.Context, id string) (Session, error)
+	Delete(ctx context.Context, id string) error
+}
+
+var (
+	ErrSessionNotFound = errors.New("session not found")
+	ErrSessionExpired  = errors.New("session expired")
+)
+
+type MemorySessionStore struct {
+	mu       sync.Mutex
+	sessions map[string]Session
+	now      func() time.Time
+	rand     func() (string, error)
+}
+
+func NewMemorySessionStore() *MemorySessionStore {
+	return &MemorySessionStore{
+		sessions: make(map[string]Session),
+		now:      time.Now,
+		rand:     randomToken,
+	}
+}
+
+func (s *MemorySessionStore) New(_ context.Context, userID string, t domain.UserType, ttl time.Duration) (Session, error) {
+	id, err := s.rand()
+	if err != nil {
+		return Session{}, err
+	}
+	csrf, err := s.rand()
+	if err != nil {
+		return Session{}, err
+	}
+	now := s.now()
+	sess := Session{
+		ID:        id,
+		UserID:    userID,
+		UserType:  t,
+		CSRFToken: csrf,
+		CreatedAt: now,
+		ExpiresAt: now.Add(ttl),
+	}
+	s.mu.Lock()
+	s.sessions[id] = sess
+	s.mu.Unlock()
+	return sess, nil
+}
+
+func (s *MemorySessionStore) Get(_ context.Context, id string) (Session, error) {
+	s.mu.Lock()
+	sess, ok := s.sessions[id]
+	s.mu.Unlock()
+	if !ok {
+		return Session{}, ErrSessionNotFound
+	}
+	if !sess.ExpiresAt.IsZero() && s.now().After(sess.ExpiresAt) {
+		// Drop expired sessions on read so the store self-cleans.
+		s.mu.Lock()
+		delete(s.sessions, id)
+		s.mu.Unlock()
+		return Session{}, ErrSessionExpired
+	}
+	return sess, nil
+}
+
+func (s *MemorySessionStore) Delete(_ context.Context, id string) error {
+	s.mu.Lock()
+	delete(s.sessions, id)
+	s.mu.Unlock()
+	return nil
+}
+
+func randomToken() (string, error) {
+	var b [32]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		return "", err
+	}
+	return base64.RawURLEncoding.EncodeToString(b[:]), nil
+}
+
+// CookieOptions controls how Set-Cookie headers are produced. Defaults satisfy
+// the issue's security non-negotiables: Secure, HttpOnly, SameSite=Lax. Tests
+// may toggle Secure off to keep httptest happy.
+type CookieOptions struct {
+	Secure   bool
+	SameSite http.SameSite
+	Path     string
+	Domain   string
+}
+
+func DefaultCookieOptions() CookieOptions {
+	return CookieOptions{
+		Secure:   true,
+		SameSite: http.SameSiteLaxMode,
+		Path:     "/",
+	}
+}
+
+// SetSessionCookie writes the session-id cookie. The session cookie is always
+// HttpOnly (no JS access). The CSRF cookie is intentionally NOT HttpOnly so
+// JS-driven forms can mirror it back.
+func SetSessionCookie(w http.ResponseWriter, sess Session, opts CookieOptions) {
+	http.SetCookie(w, &http.Cookie{
+		Name:     SessionCookieName,
+		Value:    sess.ID,
+		Path:     opts.Path,
+		Domain:   opts.Domain,
+		Expires:  sess.ExpiresAt,
+		MaxAge:   int(time.Until(sess.ExpiresAt).Seconds()),
+		Secure:   opts.Secure,
+		HttpOnly: true,
+		SameSite: opts.SameSite,
+	})
+	http.SetCookie(w, &http.Cookie{
+		Name:     CSRFCookieName,
+		Value:    sess.CSRFToken,
+		Path:     opts.Path,
+		Domain:   opts.Domain,
+		Expires:  sess.ExpiresAt,
+		MaxAge:   int(time.Until(sess.ExpiresAt).Seconds()),
+		Secure:   opts.Secure,
+		HttpOnly: false,
+		SameSite: opts.SameSite,
+	})
+}
+
+// ClearSessionCookies expires both cookies immediately.
+func ClearSessionCookies(w http.ResponseWriter, opts CookieOptions) {
+	for _, name := range []string{SessionCookieName, CSRFCookieName} {
+		http.SetCookie(w, &http.Cookie{
+			Name:     name,
+			Value:    "",
+			Path:     opts.Path,
+			Domain:   opts.Domain,
+			Expires:  time.Unix(0, 0),
+			MaxAge:   -1,
+			Secure:   opts.Secure,
+			HttpOnly: name == SessionCookieName,
+			SameSite: opts.SameSite,
+		})
+	}
+}

--- a/internal/batch/doc.go
+++ b/internal/batch/doc.go
@@ -1,0 +1,22 @@
+// Package batch contains the CardDemo batch-job implementations (ADR 0006).
+//
+// Each JCL job step is replaced by a Go function invoked via the cmd/batch CLI.
+// A thin YAML orchestrator (configs/orchestrator.yaml) replaces JCL job-stream
+// sequencing; the functions themselves have no JCL-level control-flow logic.
+//
+// JCL step → batch function mapping:
+//
+//	POSTTRAN.jcl   (CBTRN01C.cbl)  → PostTransaction     (RAU-44)
+//	TRANCATG.jcl   (CBTRN02C.cbl)  → CategorizeTransaction (RAU-44)
+//	DALYREJS.jcl   (CBTRN03C.cbl)  → DailyRejects        (RAU-44)
+//	ACCTFILE.jcl   (CBACT01C.cbl)  → AccountFile         (RAU-44)
+//	INTCALC.jcl    (CBACT02C.cbl)  → InterestCalc        (RAU-44)
+//	TCATBALF.jcl   (CBACT03C.cbl)  → TcatBalance         (RAU-44)
+//	READACCT.jcl   (CBACT04C.cbl)  → ReadAccount         (RAU-44)
+//	CUSTFILE.jcl   (CBCUS01C.cbl)  → CustomerFile        (RAU-44)
+//	CREASTMT.JCL   (CBSTM03A.CBL)  → CreateStatement     (RAU-44)
+//	REPTFILE.jcl   (CBSTM03B.CBL)  → ReportFile          (RAU-44)
+//	CBEXPORT.jcl   (CBEXPORT.cbl)  → Export              (RAU-44)
+//	CBIMPORT.jcl   (CBIMPORT.cbl)  → Import              (RAU-44)
+//	COMBTRAN.jcl   (orchestration) → CombineTransactions  (RAU-44)
+package batch

--- a/internal/cobolfmt/binary.go
+++ b/internal/cobolfmt/binary.go
@@ -1,0 +1,84 @@
+package cobolfmt
+
+import (
+	"encoding/binary"
+	"fmt"
+)
+
+// CompSize returns the storage size in bytes for a COMP (binary) field with n digits.
+//
+// IBM COBOL binary storage:
+//   - PIC 9(1)–9(4):   2 bytes (halfword)
+//   - PIC 9(5)–9(9):   4 bytes (fullword)
+//   - PIC 9(10)–9(18): 8 bytes (doubleword)
+func CompSize(digits int) int {
+	switch {
+	case digits <= 4:
+		return 2
+	case digits <= 9:
+		return 4
+	default:
+		return 8
+	}
+}
+
+// DecodeComp decodes a big-endian COMP (binary) integer field.
+//
+// Parameters:
+//   - b: raw bytes (must be 2, 4, or 8 bytes).
+//   - signed: true for PIC S9…, false for PIC 9….
+func DecodeComp(b []byte, signed bool) (int64, error) {
+	switch len(b) {
+	case 2:
+		if signed {
+			return int64(int16(binary.BigEndian.Uint16(b))), nil
+		}
+		return int64(binary.BigEndian.Uint16(b)), nil
+	case 4:
+		if signed {
+			return int64(int32(binary.BigEndian.Uint32(b))), nil
+		}
+		return int64(binary.BigEndian.Uint32(b)), nil
+	case 8:
+		if signed {
+			return int64(binary.BigEndian.Uint64(b)), nil
+		}
+		u := binary.BigEndian.Uint64(b)
+		if u > (1<<63 - 1) {
+			return 0, fmt.Errorf("cobolfmt: binary: unsigned value %d overflows int64", u)
+		}
+		return int64(u), nil
+	default:
+		return 0, fmt.Errorf("cobolfmt: binary: unsupported field size %d (must be 2, 4, or 8)", len(b))
+	}
+}
+
+// EncodeComp encodes an integer value into a big-endian COMP field.
+//
+// Parameters:
+//   - v: value to encode.
+//   - size: field size in bytes (2, 4, or 8).
+func EncodeComp(v int64, size int) ([]byte, error) {
+	out := make([]byte, size)
+	switch size {
+	case 2:
+		binary.BigEndian.PutUint16(out, uint16(v))
+	case 4:
+		binary.BigEndian.PutUint32(out, uint32(v))
+	case 8:
+		binary.BigEndian.PutUint64(out, uint64(v))
+	default:
+		return nil, fmt.Errorf("cobolfmt: binary: unsupported field size %d (must be 2, 4, or 8)", size)
+	}
+	return out, nil
+}
+
+// DecodeCompDigits is a convenience function that selects the field size based on
+// the number of PIC digits and decodes the value.
+func DecodeCompDigits(b []byte, digits int, signed bool) (int64, error) {
+	expected := CompSize(digits)
+	if len(b) != expected {
+		return 0, fmt.Errorf("cobolfmt: binary: expected %d bytes for %d-digit COMP field, got %d", expected, digits, len(b))
+	}
+	return DecodeComp(b, signed)
+}

--- a/internal/cobolfmt/binary_test.go
+++ b/internal/cobolfmt/binary_test.go
@@ -1,0 +1,102 @@
+package cobolfmt_test
+
+import (
+	"testing"
+
+	"github.com/aws-samples/aws-mainframe-modernization-carddemo/internal/cobolfmt"
+)
+
+func TestCompSize(t *testing.T) {
+	tests := []struct {
+		digits int
+		want   int
+	}{
+		{1, 2},
+		{2, 2},
+		{4, 2},
+		{5, 4},
+		{9, 4},
+		{10, 8},
+		{18, 8},
+	}
+	for _, tc := range tests {
+		got := cobolfmt.CompSize(tc.digits)
+		if got != tc.want {
+			t.Errorf("CompSize(%d) = %d, want %d", tc.digits, got, tc.want)
+		}
+	}
+}
+
+func TestDecodeComp(t *testing.T) {
+	tests := []struct {
+		name   string
+		input  []byte
+		signed bool
+		want   int64
+	}{
+		{"unsigned 0 (2 bytes)", []byte{0x00, 0x00}, false, 0},
+		{"unsigned 1 (2 bytes)", []byte{0x00, 0x01}, false, 1},
+		{"unsigned 65535 (2 bytes)", []byte{0xFF, 0xFF}, false, 65535},
+		{"unsigned 1 (4 bytes)", []byte{0x00, 0x00, 0x00, 0x01}, false, 1},
+		{"unsigned 1000000 (4 bytes)", []byte{0x00, 0x0F, 0x42, 0x40}, false, 1000000},
+		{"signed -1 (2 bytes)", []byte{0xFF, 0xFF}, true, -1},
+		{"signed -1 (4 bytes)", []byte{0xFF, 0xFF, 0xFF, 0xFF}, true, -1},
+		{"signed 100 (4 bytes)", []byte{0x00, 0x00, 0x00, 0x64}, true, 100},
+		{"unsigned 1 (8 bytes)", []byte{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01}, false, 1},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := cobolfmt.DecodeComp(tc.input, tc.signed)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tc.want {
+				t.Errorf("got %d, want %d", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestEncodeCompRoundTrip(t *testing.T) {
+	tests := []struct {
+		value  int64
+		size   int
+		signed bool
+	}{
+		{0, 2, true},
+		{1, 2, true},
+		{32767, 2, true},  // max positive for signed 2-byte
+		{-1, 2, true},
+		{65535, 2, false}, // unsigned 2-byte max
+		{100000, 4, true},
+		{-1, 4, true},
+		{1234567890, 8, true},
+		{-9876543210, 8, true},
+	}
+
+	for _, tc := range tests {
+		encoded, err := cobolfmt.EncodeComp(tc.value, tc.size)
+		if err != nil {
+			t.Fatalf("EncodeComp(%d, %d): %v", tc.value, tc.size, err)
+		}
+		if len(encoded) != tc.size {
+			t.Fatalf("encoded length: got %d, want %d", len(encoded), tc.size)
+		}
+
+		decoded, err := cobolfmt.DecodeComp(encoded, tc.signed)
+		if err != nil {
+			t.Fatalf("DecodeComp: %v", err)
+		}
+		if decoded != tc.value {
+			t.Errorf("round-trip(value=%d, size=%d, signed=%v): got %d, want %d", tc.value, tc.size, tc.signed, decoded, tc.value)
+		}
+	}
+}
+
+func TestDecodeCompError(t *testing.T) {
+	_, err := cobolfmt.DecodeComp([]byte{0x00, 0x00, 0x00}, false)
+	if err == nil {
+		t.Error("expected error for 3-byte input, got nil")
+	}
+}

--- a/internal/cobolfmt/date.go
+++ b/internal/cobolfmt/date.go
@@ -1,0 +1,114 @@
+package cobolfmt
+
+import (
+	"fmt"
+	"time"
+)
+
+// ParseDate8 parses a COBOL YYYYMMDD date string (8 characters).
+// Returns time.Time in UTC. Returns zero time and error for blank/invalid input.
+func ParseDate8(s string) (time.Time, error) {
+	if isBlank(s) {
+		return time.Time{}, nil
+	}
+	t, err := time.Parse("20060102", s)
+	if err != nil {
+		return time.Time{}, fmt.Errorf("cobolfmt: date: invalid YYYYMMDD %q: %w", s, err)
+	}
+	return t, nil
+}
+
+// ParseDate10ISO parses a COBOL YYYY-MM-DD date string (10 characters).
+// Returns time.Time in UTC. Returns zero time for blank input.
+func ParseDate10ISO(s string) (time.Time, error) {
+	if isBlank(s) {
+		return time.Time{}, nil
+	}
+	t, err := time.Parse("2006-01-02", s)
+	if err != nil {
+		return time.Time{}, fmt.Errorf("cobolfmt: date: invalid YYYY-MM-DD %q: %w", s, err)
+	}
+	return t, nil
+}
+
+// FormatDate8 formats a time.Time as YYYYMMDD.
+// Returns 8 spaces for zero time (matches COBOL blank date convention).
+func FormatDate8(t time.Time) string {
+	if t.IsZero() {
+		return "        "
+	}
+	return t.UTC().Format("20060102")
+}
+
+// FormatDate10ISO formats a time.Time as YYYY-MM-DD.
+// Returns 10 spaces for zero time.
+func FormatDate10ISO(t time.Time) string {
+	if t.IsZero() {
+		return "          "
+	}
+	return t.UTC().Format("2006-01-02")
+}
+
+// ParseDate6 parses a YYMMDD date string (6 characters), interpreting YY ≥ 40 as
+// 19YY and YY < 40 as 20YY (common COBOL windowing rule).
+func ParseDate6(s string) (time.Time, error) {
+	if isBlank(s) {
+		return time.Time{}, nil
+	}
+	if len(s) != 6 {
+		return time.Time{}, fmt.Errorf("cobolfmt: date: YYMMDD must be 6 chars, got %d", len(s))
+	}
+
+	var yy int
+	fmt.Sscanf(s[:2], "%d", &yy)
+	century := 2000
+	if yy >= 40 {
+		century = 1900
+	}
+	full := fmt.Sprintf("%d%s", century+yy, s[2:])
+	t, err := time.Parse("20060102", full)
+	if err != nil {
+		return time.Time{}, fmt.Errorf("cobolfmt: date: invalid YYMMDD %q: %w", s, err)
+	}
+	return t, nil
+}
+
+// ParseTimestamp26 parses a COBOL 26-character timestamp of the form
+// "YYYY-MM-DD HH:MM:SS.ffffff" or "YYYY-MM-DDTHH:MM:SS.ffffff".
+// Returns zero time for blank input.
+func ParseTimestamp26(s string) (time.Time, error) {
+	s = TrimRight(s)
+	if s == "" {
+		return time.Time{}, nil
+	}
+	layouts := []string{
+		"2006-01-02 15:04:05.000000",
+		"2006-01-02T15:04:05.000000",
+		"2006-01-02 15:04:05",
+		"2006-01-02T15:04:05",
+	}
+	for _, layout := range layouts {
+		if t, err := time.Parse(layout, s); err == nil {
+			return t, nil
+		}
+	}
+	return time.Time{}, fmt.Errorf("cobolfmt: date: cannot parse timestamp %q", s)
+}
+
+// FormatTimestamp26 formats a time.Time into a 26-character COBOL timestamp string
+// "YYYY-MM-DD HH:MM:SS.ffffff". Returns 26 spaces for zero time.
+func FormatTimestamp26(t time.Time) string {
+	if t.IsZero() {
+		return "                          "
+	}
+	return t.UTC().Format("2006-01-02 15:04:05.000000")
+}
+
+func isBlank(s string) bool {
+	for _, ch := range s {
+		if ch != ' ' && ch != '0' && ch != '-' && ch != '/' {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/cobolfmt/date_test.go
+++ b/internal/cobolfmt/date_test.go
@@ -1,0 +1,131 @@
+package cobolfmt_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/aws-samples/aws-mainframe-modernization-carddemo/internal/cobolfmt"
+)
+
+func TestParseDate10ISO(t *testing.T) {
+	tests := []struct {
+		input   string
+		wantY   int
+		wantM   time.Month
+		wantD   int
+		wantErr bool
+	}{
+		{"2014-11-20", 2014, time.November, 20, false},
+		{"2025-05-20", 2025, time.May, 20, false},
+		{"1961-06-08", 1961, time.June, 8, false},
+		{"          ", 0, 0, 0, false},  // blank → zero time
+		{"0000-00-00", 0, 0, 0, false},  // all zeros → zero time
+		{"bad-date", 0, 0, 0, true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.input, func(t *testing.T) {
+			got, err := cobolfmt.ParseDate10ISO(tc.input)
+			if tc.wantErr {
+				if err == nil {
+					t.Errorf("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if tc.wantY == 0 {
+				if !got.IsZero() {
+					t.Errorf("expected zero time, got %v", got)
+				}
+				return
+			}
+			if got.Year() != tc.wantY || got.Month() != tc.wantM || got.Day() != tc.wantD {
+				t.Errorf("got %v, want %d-%02d-%02d", got, tc.wantY, tc.wantM, tc.wantD)
+			}
+		})
+	}
+}
+
+func TestParseDate8(t *testing.T) {
+	tests := []struct {
+		input string
+		wantY int
+		wantM time.Month
+		wantD int
+	}{
+		{"20141120", 2014, time.November, 20},
+		{"19610608", 1961, time.June, 8},
+	}
+
+	for _, tc := range tests {
+		got, err := cobolfmt.ParseDate8(tc.input)
+		if err != nil {
+			t.Fatalf("ParseDate8(%q): %v", tc.input, err)
+		}
+		if got.Year() != tc.wantY || got.Month() != tc.wantM || got.Day() != tc.wantD {
+			t.Errorf("got %v, want %d-%02d-%02d", got, tc.wantY, tc.wantM, tc.wantD)
+		}
+	}
+}
+
+func TestFormatDate10ISO(t *testing.T) {
+	d := time.Date(2014, time.November, 20, 0, 0, 0, 0, time.UTC)
+	got := cobolfmt.FormatDate10ISO(d)
+	if got != "2014-11-20" {
+		t.Errorf("got %q, want %q", got, "2014-11-20")
+	}
+}
+
+func TestFormatDate10ISOZero(t *testing.T) {
+	got := cobolfmt.FormatDate10ISO(time.Time{})
+	if len(got) != 10 {
+		t.Errorf("zero time format: got %q (len %d), want 10 spaces", got, len(got))
+	}
+}
+
+func TestParseDate6LeapYear(t *testing.T) {
+	// 2000-02-29 is valid (leap year)
+	got, err := cobolfmt.ParseDate6("000229")
+	if err != nil {
+		t.Fatalf("ParseDate6(000229): %v", err)
+	}
+	if got.Year() != 2000 || got.Month() != time.February || got.Day() != 29 {
+		t.Errorf("got %v, want 2000-02-29", got)
+	}
+}
+
+func TestParseDate6Windowing(t *testing.T) {
+	// YY=40 → 1940, YY=39 → 2039
+	tests := []struct {
+		input string
+		wantY int
+	}{
+		{"400101", 1940},
+		{"390101", 2039},
+		{"000101", 2000},
+		{"990101", 1999},
+	}
+	for _, tc := range tests {
+		got, err := cobolfmt.ParseDate6(tc.input)
+		if err != nil {
+			t.Fatalf("ParseDate6(%q): %v", tc.input, err)
+		}
+		if got.Year() != tc.wantY {
+			t.Errorf("input %q: got year %d, want %d", tc.input, got.Year(), tc.wantY)
+		}
+	}
+}
+
+func TestTimestamp26RoundTrip(t *testing.T) {
+	orig := "2023-11-15 14:30:00.000000"
+	ts, err := cobolfmt.ParseTimestamp26(orig)
+	if err != nil {
+		t.Fatalf("ParseTimestamp26: %v", err)
+	}
+	got := cobolfmt.FormatTimestamp26(ts)
+	if got != orig {
+		t.Errorf("round-trip: got %q, want %q", got, orig)
+	}
+}

--- a/internal/cobolfmt/doc.go
+++ b/internal/cobolfmt/doc.go
@@ -1,0 +1,20 @@
+// Package cobolfmt provides helpers for COBOL data-format conversions.
+//
+// COBOL programs use packed-decimal (COMP-3), zoned-decimal (DISPLAY NUMERIC),
+// and fixed-width alphanumeric (PIC X) fields that have no direct Go equivalent.
+// This package centralises those conversions so the domain and repo layers
+// stay format-agnostic.
+//
+// Key conversions (to be implemented as porting progresses):
+//
+//	Comp3Decode(b []byte, scale int) decimal.Decimal   — packed-decimal → decimal
+//	Comp3Encode(d decimal.Decimal, width int) []byte   — decimal → packed-decimal
+//	ZonedDecode(b []byte, scale int) decimal.Decimal   — zoned-decimal → decimal
+//	PadRight(s string, n int) string                   — PIC X(n) SPACE fill
+//	TrimRight(s string) string                         — remove SPACE fill
+//	ParseDate6(s string) (time.Time, error)            — YYMMDD → time.Time
+//	ParseDate8(s string) (time.Time, error)            — YYYYMMDD → time.Time
+//
+// All monetary fields in the domain package use github.com/shopspring/decimal;
+// float64 is never used for money (ADR 0007).
+package cobolfmt

--- a/internal/cobolfmt/ebcdic.go
+++ b/internal/cobolfmt/ebcdic.go
@@ -1,0 +1,85 @@
+// Package cobolfmt provides helpers for COBOL data-format conversions.
+package cobolfmt
+
+import (
+	"bytes"
+	"strings"
+
+	"golang.org/x/text/encoding/charmap"
+)
+
+// ebcdicCP037 is the EBCDIC code page 037 codec used by IBM z/OS (North America).
+var ebcdicCP037 = charmap.CodePage037
+
+// ebcdicSpace is the EBCDIC representation of a space character (0x40).
+const ebcdicSpace = byte(0x40)
+
+// DecodeEBCDIC converts a []byte in EBCDIC CP037 to a UTF-8 string.
+func DecodeEBCDIC(b []byte) (string, error) {
+	dec := ebcdicCP037.NewDecoder()
+	out, err := dec.Bytes(b)
+	if err != nil {
+		return "", err
+	}
+	return string(out), nil
+}
+
+// DecodeEBCDICTrimmed converts EBCDIC CP037 bytes to UTF-8 and trims trailing spaces.
+func DecodeEBCDICTrimmed(b []byte) (string, error) {
+	s, err := DecodeEBCDIC(b)
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimRight(s, " "), nil
+}
+
+// EncodeEBCDIC converts a UTF-8 string to a fixed-width EBCDIC CP037 []byte of
+// exactly n bytes. Shorter strings are right-padded with EBCDIC spaces (0x40).
+// Longer strings are silently truncated to n bytes.
+func EncodeEBCDIC(s string, n int) ([]byte, error) {
+	enc := ebcdicCP037.NewEncoder()
+	encoded, err := enc.Bytes([]byte(s))
+	if err != nil {
+		return nil, err
+	}
+	result := make([]byte, n)
+	// Fill with EBCDIC spaces first.
+	for i := range result {
+		result[i] = ebcdicSpace
+	}
+	copy(result, encoded)
+	return result, nil
+}
+
+// EncodeEBCDICRaw encodes a UTF-8 string and returns the raw EBCDIC bytes without
+// any padding or truncation. Useful when the caller controls the exact field length.
+func EncodeEBCDICRaw(s string) ([]byte, error) {
+	enc := ebcdicCP037.NewEncoder()
+	return enc.Bytes([]byte(s))
+}
+
+// PadRight pads or truncates a string to exactly n bytes in the Go string sense,
+// space-padding on the right. This mirrors COBOL MOVE of a shorter string into a
+// PIC X(n) field. Use before EncodeEBCDIC when you want to control ASCII padding.
+func PadRight(s string, n int) string {
+	if len(s) >= n {
+		return s[:n]
+	}
+	return s + strings.Repeat(" ", n-len(s))
+}
+
+// TrimRight removes trailing ASCII spaces from a field read back from ASCII storage.
+func TrimRight(s string) string {
+	return strings.TrimRight(s, " ")
+}
+
+// EBCDICSpacePad returns n EBCDIC space bytes (0x40). Useful for blank fillers.
+func EBCDICSpacePad(n int) []byte {
+	return bytes.Repeat([]byte{ebcdicSpace}, n)
+}
+
+// EBCDICZeroPad returns n EBCDIC '0' bytes (0xF0). Used for numeric FILLER fields
+// that are initialized to ZEROS rather than SPACES (e.g. TranType, DiscGroup records).
+func EBCDICZeroPad(n int) []byte {
+	return bytes.Repeat([]byte{0xF0}, n)
+}

--- a/internal/cobolfmt/ebcdic_test.go
+++ b/internal/cobolfmt/ebcdic_test.go
@@ -1,0 +1,141 @@
+package cobolfmt_test
+
+import (
+	"testing"
+
+	"github.com/aws-samples/aws-mainframe-modernization-carddemo/internal/cobolfmt"
+)
+
+func TestDecodeEBCDIC(t *testing.T) {
+	tests := []struct {
+		name  string
+		input []byte
+		want  string
+	}{
+		// EBCDIC CP037 values for ASCII printable characters
+		{
+			name:  "space (0x40)",
+			input: []byte{0x40},
+			want:  " ",
+		},
+		{
+			name:  "A (0xC1)",
+			input: []byte{0xC1},
+			want:  "A",
+		},
+		{
+			name:  "Z (0xE9)",
+			input: []byte{0xE9},
+			want:  "Z",
+		},
+		{
+			name:  "a (0x81)",
+			input: []byte{0x81},
+			want:  "a",
+		},
+		{
+			name:  "z (0xA9)",
+			input: []byte{0xA9},
+			want:  "z",
+		},
+		{
+			name:  "digit 0 (0xF0)",
+			input: []byte{0xF0},
+			want:  "0",
+		},
+		{
+			name:  "digit 9 (0xF9)",
+			input: []byte{0xF9},
+			want:  "9",
+		},
+		{
+			name:  "Immanuel (from CUSTDATA.PS)",
+			input: []byte{0xC9, 0x94, 0x94, 0x81, 0x95, 0xA4, 0x85, 0x93},
+			want:  "Immanuel",
+		},
+		{
+			name:  "hyphen/minus (0x60)",
+			input: []byte{0x60},
+			want:  "-",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := cobolfmt.DecodeEBCDIC(tc.input)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tc.want {
+				t.Errorf("got %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestEncodeEBCDICRoundTrip(t *testing.T) {
+	// Round-trip test: every printable ASCII character should survive EBCDIC encode → decode.
+	printable := make([]byte, 0, 95)
+	for c := byte(0x20); c <= 0x7E; c++ {
+		printable = append(printable, c)
+	}
+	input := string(printable)
+
+	encoded, err := cobolfmt.EncodeEBCDIC(input, len(input))
+	if err != nil {
+		t.Fatalf("EncodeEBCDIC: %v", err)
+	}
+
+	decoded, err := cobolfmt.DecodeEBCDIC(encoded)
+	if err != nil {
+		t.Fatalf("DecodeEBCDIC: %v", err)
+	}
+
+	if decoded != input {
+		t.Errorf("round-trip failed:\ngot  %q\nwant %q", decoded, input)
+	}
+}
+
+func TestEncodeEBCDICPadding(t *testing.T) {
+	// EncodeEBCDIC pads shorter strings with EBCDIC spaces (0x40).
+	encoded, err := cobolfmt.EncodeEBCDIC("AB", 5)
+	if err != nil {
+		t.Fatalf("EncodeEBCDIC: %v", err)
+	}
+	if len(encoded) != 5 {
+		t.Fatalf("length: got %d, want 5", len(encoded))
+	}
+	// bytes 2-4 should be EBCDIC space (0x40)
+	for i := 2; i < 5; i++ {
+		if encoded[i] != 0x40 {
+			t.Errorf("byte[%d] = 0x%02X, want 0x40", i, encoded[i])
+		}
+	}
+}
+
+func TestDecodeEBCDICTrimmed(t *testing.T) {
+	// "AB   " (padded with EBCDIC spaces) should decode to "AB"
+	input := []byte{0xC1, 0xC2, 0x40, 0x40, 0x40}
+	got, err := cobolfmt.DecodeEBCDICTrimmed(input)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "AB" {
+		t.Errorf("got %q, want %q", got, "AB")
+	}
+}
+
+func TestEncodeEBCDICTruncation(t *testing.T) {
+	// Strings longer than n are truncated.
+	encoded, err := cobolfmt.EncodeEBCDIC("ABCDE", 3)
+	if err != nil {
+		t.Fatalf("EncodeEBCDIC: %v", err)
+	}
+	if len(encoded) != 3 {
+		t.Fatalf("length: got %d, want 3", len(encoded))
+	}
+	decoded, _ := cobolfmt.DecodeEBCDIC(encoded)
+	if decoded != "ABC" {
+		t.Errorf("got %q, want %q", decoded, "ABC")
+	}
+}

--- a/internal/cobolfmt/packed.go
+++ b/internal/cobolfmt/packed.go
@@ -1,0 +1,152 @@
+package cobolfmt
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/shopspring/decimal"
+)
+
+// PackedSize returns the storage size in bytes for a COMP-3 (packed decimal) field
+// with the given total number of digits (integer + decimal).
+//
+// IBM COBOL packs each digit into one nibble; the last nibble is the sign.
+// Storage = ⌈(digits + 1) / 2⌉.
+func PackedSize(digits int) int {
+	return (digits + 2) / 2 // equivalent to ceil((digits+1)/2)
+}
+
+// DecodePacked decodes a COMP-3 packed-decimal field.
+//
+// Layout: each byte holds two BCD digits in its high and low nibbles.
+// The very last nibble is the sign: 0xC or 0xF = positive, 0xD = negative.
+// The first nibble of the first byte may be 0 (padding for even-digit fields).
+//
+// Parameters:
+//   - b: raw bytes of the COMP-3 field.
+//   - scale: implied decimal digits (V in PICTURE clause).
+func DecodePacked(b []byte, scale int) (decimal.Decimal, error) {
+	if len(b) == 0 {
+		return decimal.Zero, nil
+	}
+
+	// Flatten nibbles; last nibble is the sign.
+	totalNibbles := len(b) * 2
+	nibbles := make([]byte, totalNibbles)
+	for i, byt := range b {
+		nibbles[i*2] = byt >> 4
+		nibbles[i*2+1] = byt & 0x0F
+	}
+
+	signNibble := nibbles[len(nibbles)-1]
+	negative := false
+	switch signNibble {
+	case 0xC, 0xF: // positive / unsigned
+	case 0xD:
+		negative = true
+	default:
+		return decimal.Zero, fmt.Errorf("cobolfmt: packed: invalid sign nibble 0x%X", signNibble)
+	}
+
+	// Digit nibbles (everything except the last nibble).
+	digitNibbles := nibbles[:len(nibbles)-1]
+	digits := make([]byte, 0, len(digitNibbles))
+	leadingZero := true
+	for _, n := range digitNibbles {
+		if n > 9 {
+			return decimal.Zero, fmt.Errorf("cobolfmt: packed: invalid digit nibble 0x%X", n)
+		}
+		if leadingZero && n == 0 {
+			continue // skip leading zeros for the integer string
+		}
+		leadingZero = false
+		digits = append(digits, '0'+n)
+	}
+
+	// Build integer string including leading zeros needed for scale.
+	raw := string(digits)
+	if raw == "" {
+		raw = "0"
+	}
+
+	// Ensure there are enough characters for the scale.
+	if scale > 0 && len(raw) <= scale {
+		raw = strings.Repeat("0", scale+1-len(raw)) + raw
+	}
+
+	var s string
+	switch {
+	case scale <= 0:
+		s = raw
+	case scale >= len(raw):
+		s = "0." + strings.Repeat("0", scale-len(raw)) + raw
+	default:
+		s = raw[:len(raw)-scale] + "." + raw[len(raw)-scale:]
+	}
+
+	d, err := decimal.NewFromString(s)
+	if err != nil {
+		return decimal.Zero, fmt.Errorf("cobolfmt: packed: %w", err)
+	}
+	if negative {
+		d = d.Neg()
+	}
+	return d, nil
+}
+
+// EncodePacked encodes a decimal.Decimal into a COMP-3 packed-decimal field.
+//
+// Parameters:
+//   - d: value to encode.
+//   - digits: total number of BCD digits in the field (integer + decimal).
+//   - scale: implied decimal digits (V in PICTURE clause).
+//
+// The encoded byte slice has length PackedSize(digits).
+func EncodePacked(d decimal.Decimal, digits, scale int) ([]byte, error) {
+	if digits <= 0 {
+		return nil, fmt.Errorf("cobolfmt: packed: digits must be > 0")
+	}
+
+	negative := d.IsNegative()
+	if negative {
+		d = d.Neg()
+	}
+
+	// Shift to remove implied decimal, then floor.
+	shifted := d.Shift(int32(scale)).Floor()
+	raw := shifted.String()
+	if idx := strings.IndexByte(raw, '.'); idx >= 0 {
+		raw = raw[:idx]
+	}
+
+	// Zero-pad to exactly `digits` digit characters.
+	if len(raw) < digits {
+		raw = strings.Repeat("0", digits-len(raw)) + raw
+	} else if len(raw) > digits {
+		raw = raw[len(raw)-digits:]
+	}
+
+	// Pack digits + sign nibble into bytes.
+	size := PackedSize(digits)
+	out := make([]byte, size)
+
+	// Build the nibble stream: leading 0 nibble (if needed) + digits + sign.
+	nibbles := make([]byte, 0, digits+1)
+	// If size*2-1 == digits, no padding nibble; otherwise first nibble = 0.
+	if (size*2 - 1) > digits {
+		nibbles = append(nibbles, 0)
+	}
+	for _, ch := range raw {
+		nibbles = append(nibbles, byte(ch-'0'))
+	}
+	if negative {
+		nibbles = append(nibbles, 0xD)
+	} else {
+		nibbles = append(nibbles, 0xC)
+	}
+
+	for i := 0; i < size; i++ {
+		out[i] = (nibbles[i*2] << 4) | nibbles[i*2+1]
+	}
+	return out, nil
+}

--- a/internal/cobolfmt/packed.go
+++ b/internal/cobolfmt/packed.go
@@ -100,9 +100,17 @@ func DecodePacked(b []byte, scale int) (decimal.Decimal, error) {
 //   - d: value to encode.
 //   - digits: total number of BCD digits in the field (integer + decimal).
 //   - scale: implied decimal digits (V in PICTURE clause).
+//   - unsigned: when true the sign nibble is 0xF (PIC 9… without S prefix);
+//     when false the sign nibble is 0xC (positive) or 0xD (negative).
+//
+// Note: negative-zero (value == 0 with a 0xD sign nibble on disk) cannot be
+// round-tripped through decimal.Decimal because the shopspring library does not
+// distinguish −0 from +0. Values decoded from a 0xD-signed zero field will
+// re-encode as 0xC. This is an accepted limitation for COMP-3 fields in this
+// package.
 //
 // The encoded byte slice has length PackedSize(digits).
-func EncodePacked(d decimal.Decimal, digits, scale int) ([]byte, error) {
+func EncodePacked(d decimal.Decimal, digits, scale int, unsigned bool) ([]byte, error) {
 	if digits <= 0 {
 		return nil, fmt.Errorf("cobolfmt: packed: digits must be > 0")
 	}
@@ -139,11 +147,16 @@ func EncodePacked(d decimal.Decimal, digits, scale int) ([]byte, error) {
 	for _, ch := range raw {
 		nibbles = append(nibbles, byte(ch-'0'))
 	}
-	if negative {
-		nibbles = append(nibbles, 0xD)
-	} else {
-		nibbles = append(nibbles, 0xC)
+	var signNibble byte
+	switch {
+	case unsigned:
+		signNibble = 0xF
+	case negative:
+		signNibble = 0xD
+	default:
+		signNibble = 0xC
 	}
+	nibbles = append(nibbles, signNibble)
 
 	for i := 0; i < size; i++ {
 		out[i] = (nibbles[i*2] << 4) | nibbles[i*2+1]

--- a/internal/cobolfmt/packed_test.go
+++ b/internal/cobolfmt/packed_test.go
@@ -1,0 +1,142 @@
+package cobolfmt_test
+
+import (
+	"testing"
+
+	"github.com/aws-samples/aws-mainframe-modernization-carddemo/internal/cobolfmt"
+	"github.com/shopspring/decimal"
+)
+
+func TestPackedSize(t *testing.T) {
+	tests := []struct {
+		digits int
+		want   int
+	}{
+		{1, 1},
+		{2, 2},
+		{3, 2},
+		{4, 3},
+		{5, 3},
+		{6, 4},
+		{7, 4},
+		{9, 5},
+		{11, 6},
+	}
+	for _, tc := range tests {
+		got := cobolfmt.PackedSize(tc.digits)
+		if got != tc.want {
+			t.Errorf("PackedSize(%d) = %d, want %d", tc.digits, got, tc.want)
+		}
+	}
+}
+
+func TestDecodePacked(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   []byte
+		scale   int
+		want    string
+		wantErr bool
+	}{
+		{
+			name:  "positive 123 (3 digits, 2 bytes)",
+			input: []byte{0x01, 0x2C}, // 01 2C = digits 0,1,2 sign=C(+)
+			scale: 0,
+			want:  "12", // leading zero is stripped, effectively digits are 1,2
+			// Actually 0x01 = hi=0,lo=1; 0x2C = hi=2,lo=C. Digits: [0,1,2], sign=C -> 12
+		},
+		{
+			name:  "negative 456",
+			input: []byte{0x04, 0x5D}, // digits 0,4,5 sign=D(-) -> -45
+			scale: 0,
+			want:  "-45",
+		},
+		{
+			name:  "zero positive",
+			input: []byte{0x0C}, // single byte: hi=0, lo=C -> digit 0, sign C -> 0
+			scale: 0,
+			want:  "0",
+		},
+		{
+			name:  "positive with scale 2",
+			input: []byte{0x01, 0x23, 0x4C}, // digits 0,1,2,3,4 sign C -> 1234 with scale2 -> 12.34
+			scale: 2,
+			want:  "12.34",
+		},
+		{
+			name:  "negative with scale 2",
+			input: []byte{0x00, 0x05, 0x0D}, // digits 0,0,0,5,0 sign D -> -50 scale2 -> -0.50
+			scale: 2,
+			want:  "-0.50",
+		},
+		{
+			name:    "invalid sign nibble",
+			input:   []byte{0x01, 0x2B}, // B is not a valid sign nibble in strict mode
+			scale:   0,
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := cobolfmt.DecodePacked(tc.input, tc.scale)
+			if tc.wantErr {
+				if err == nil {
+					t.Errorf("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			want, _ := decimal.NewFromString(tc.want)
+			if !got.Equal(want) {
+				t.Errorf("got %s, want %s", got, want)
+			}
+		})
+	}
+}
+
+func TestEncodePackedRoundTrip(t *testing.T) {
+	tests := []struct {
+		name   string
+		value  string
+		digits int
+		scale  int
+	}{
+		{"positive 0", "0", 3, 0},
+		{"positive 123", "123", 3, 0},
+		{"negative 45", "-45", 3, 0},
+		{"positive 12.34", "12.34", 5, 2},
+		{"negative 0.50", "-0.50", 3, 2},
+		{"odd digits 9", "9", 1, 0},
+		{"even digits 99", "99", 2, 0},
+		{"large 9999999.99", "9999999.99", 9, 2},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			d, err := decimal.NewFromString(tc.value)
+			if err != nil {
+				t.Fatalf("invalid decimal: %v", err)
+			}
+
+			encoded, err := cobolfmt.EncodePacked(d, tc.digits, tc.scale)
+			if err != nil {
+				t.Fatalf("EncodePacked: %v", err)
+			}
+			wantSize := cobolfmt.PackedSize(tc.digits)
+			if len(encoded) != wantSize {
+				t.Fatalf("encoded length: got %d, want %d", len(encoded), wantSize)
+			}
+
+			decoded, err := cobolfmt.DecodePacked(encoded, tc.scale)
+			if err != nil {
+				t.Fatalf("DecodePacked: %v", err)
+			}
+			if !decoded.Equal(d) {
+				t.Errorf("round-trip: got %s, want %s", decoded, d)
+			}
+		})
+	}
+}

--- a/internal/cobolfmt/packed_test.go
+++ b/internal/cobolfmt/packed_test.go
@@ -1,6 +1,7 @@
 package cobolfmt_test
 
 import (
+	"bytes"
 	"testing"
 
 	"github.com/aws-samples/aws-mainframe-modernization-carddemo/internal/cobolfmt"
@@ -39,39 +40,52 @@ func TestDecodePacked(t *testing.T) {
 		wantErr bool
 	}{
 		{
-			name:  "positive 123 (3 digits, 2 bytes)",
-			input: []byte{0x01, 0x2C}, // 01 2C = digits 0,1,2 sign=C(+)
+			name:  "positive 123 (3 digits, 2 bytes, sign C)",
+			input: []byte{0x01, 0x2C}, // digits 0,1,2 sign=C(+) -> 12
 			scale: 0,
-			want:  "12", // leading zero is stripped, effectively digits are 1,2
-			// Actually 0x01 = hi=0,lo=1; 0x2C = hi=2,lo=C. Digits: [0,1,2], sign=C -> 12
+			want:  "12",
 		},
 		{
-			name:  "negative 456",
+			name:  "unsigned 123 (3 digits, 2 bytes, sign F)",
+			input: []byte{0x01, 0x2F}, // digits 0,1,2 sign=F(unsigned) -> 12
+			scale: 0,
+			want:  "12",
+		},
+		{
+			name:  "negative 456 (sign D)",
 			input: []byte{0x04, 0x5D}, // digits 0,4,5 sign=D(-) -> -45
 			scale: 0,
 			want:  "-45",
 		},
 		{
-			name:  "zero positive",
-			input: []byte{0x0C}, // single byte: hi=0, lo=C -> digit 0, sign C -> 0
+			name:  "zero positive (sign C)",
+			input: []byte{0x0C},
+			scale: 0,
+			want:  "0",
+		},
+		{
+			// negative-zero: 0xD sign over zero digits decodes to 0 (sign info lost).
+			// Re-encoding as signed will produce 0xC, not 0xD — known shopspring limitation.
+			name:  "negative-zero (sign D, all-zero digits) decodes to 0",
+			input: []byte{0x00, 0x0D},
 			scale: 0,
 			want:  "0",
 		},
 		{
 			name:  "positive with scale 2",
-			input: []byte{0x01, 0x23, 0x4C}, // digits 0,1,2,3,4 sign C -> 1234 with scale2 -> 12.34
+			input: []byte{0x01, 0x23, 0x4C}, // digits 0,1,2,3,4 sign C -> 12.34
 			scale: 2,
 			want:  "12.34",
 		},
 		{
 			name:  "negative with scale 2",
-			input: []byte{0x00, 0x05, 0x0D}, // digits 0,0,0,5,0 sign D -> -50 scale2 -> -0.50
+			input: []byte{0x00, 0x05, 0x0D}, // digits 0,0,0,5,0 sign D -> -0.50
 			scale: 2,
 			want:  "-0.50",
 		},
 		{
 			name:    "invalid sign nibble",
-			input:   []byte{0x01, 0x2B}, // B is not a valid sign nibble in strict mode
+			input:   []byte{0x01, 0x2B},
 			scale:   0,
 			wantErr: true,
 		},
@@ -97,21 +111,96 @@ func TestDecodePacked(t *testing.T) {
 	}
 }
 
+func TestEncodePackedUnsigned(t *testing.T) {
+	// unsigned=true must produce 0xF sign nibble regardless of value sign.
+	tests := []struct {
+		name     string
+		value    string
+		digits   int
+		scale    int
+		wantHex  []byte
+	}{
+		{
+			name:    "unsigned 123 (3 digits) -> 12 3F",
+			value:   "123",
+			digits:  3,
+			scale:   0,
+			wantHex: []byte{0x12, 0x3F},
+		},
+		{
+			name:    "unsigned 0 (3 digits) -> 00 0F",
+			value:   "0",
+			digits:  3,
+			scale:   0,
+			wantHex: []byte{0x00, 0x0F},
+		},
+		{
+			name:    "unsigned 300 (3 digits) -> 30 0F",
+			value:   "300",
+			digits:  3,
+			scale:   0,
+			wantHex: []byte{0x30, 0x0F},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			d, _ := decimal.NewFromString(tc.value)
+			encoded, err := cobolfmt.EncodePacked(d, tc.digits, tc.scale, true)
+			if err != nil {
+				t.Fatalf("EncodePacked: %v", err)
+			}
+			if !bytes.Equal(encoded, tc.wantHex) {
+				t.Errorf("got %X, want %X", encoded, tc.wantHex)
+			}
+		})
+	}
+}
+
+func TestEncodePackedUnsignedRoundTrip(t *testing.T) {
+	// Unsigned round-trip: encode with 0xF, decode (accepts 0xF as positive).
+	values := []string{"0", "1", "123", "300", "776", "999"}
+	for _, v := range values {
+		t.Run(v, func(t *testing.T) {
+			d, _ := decimal.NewFromString(v)
+			encoded, err := cobolfmt.EncodePacked(d, 3, 0, true)
+			if err != nil {
+				t.Fatalf("EncodePacked: %v", err)
+			}
+			// Sign nibble must be 0xF.
+			if encoded[len(encoded)-1]&0x0F != 0xF {
+				t.Errorf("sign nibble: got 0x%X, want 0xF", encoded[len(encoded)-1]&0x0F)
+			}
+			decoded, err := cobolfmt.DecodePacked(encoded, 0)
+			if err != nil {
+				t.Fatalf("DecodePacked: %v", err)
+			}
+			if !decoded.Equal(d) {
+				t.Errorf("round-trip: got %s, want %s", decoded, d)
+			}
+		})
+	}
+}
+
 func TestEncodePackedRoundTrip(t *testing.T) {
 	tests := []struct {
-		name   string
-		value  string
-		digits int
-		scale  int
+		name     string
+		value    string
+		digits   int
+		scale    int
+		unsigned bool
 	}{
-		{"positive 0", "0", 3, 0},
-		{"positive 123", "123", 3, 0},
-		{"negative 45", "-45", 3, 0},
-		{"positive 12.34", "12.34", 5, 2},
-		{"negative 0.50", "-0.50", 3, 2},
-		{"odd digits 9", "9", 1, 0},
-		{"even digits 99", "99", 2, 0},
-		{"large 9999999.99", "9999999.99", 9, 2},
+		{"positive 0 signed", "0", 3, 0, false},
+		{"positive 123 signed", "123", 3, 0, false},
+		{"negative 45 signed", "-45", 3, 0, false},
+		{"positive 12.34 signed", "12.34", 5, 2, false},
+		{"negative 0.50 signed", "-0.50", 3, 2, false},
+		{"odd digits 9 signed", "9", 1, 0, false},
+		{"even digits 99 signed", "99", 2, 0, false},
+		{"large 9999999.99 signed", "9999999.99", 9, 2, false},
+		{"unsigned 123", "123", 3, 0, true},
+		{"unsigned 0", "0", 3, 0, true},
+		{"unsigned 999", "999", 3, 0, true},
 	}
 
 	for _, tc := range tests {
@@ -121,7 +210,7 @@ func TestEncodePackedRoundTrip(t *testing.T) {
 				t.Fatalf("invalid decimal: %v", err)
 			}
 
-			encoded, err := cobolfmt.EncodePacked(d, tc.digits, tc.scale)
+			encoded, err := cobolfmt.EncodePacked(d, tc.digits, tc.scale, tc.unsigned)
 			if err != nil {
 				t.Fatalf("EncodePacked: %v", err)
 			}
@@ -136,6 +225,38 @@ func TestEncodePackedRoundTrip(t *testing.T) {
 			}
 			if !decoded.Equal(d) {
 				t.Errorf("round-trip: got %s, want %s", decoded, d)
+			}
+		})
+	}
+}
+
+func TestEncodePackedSignNibble(t *testing.T) {
+	// Verify exact sign nibble values for signed vs unsigned encoding.
+	d := decimal.NewFromInt(5)
+	neg := decimal.NewFromInt(-5)
+
+	tests := []struct {
+		name      string
+		d         decimal.Decimal
+		unsigned  bool
+		wantNibble byte
+	}{
+		{"positive signed -> 0xC", d, false, 0xC},
+		{"negative signed -> 0xD", neg, false, 0xD},
+		{"positive unsigned -> 0xF", d, true, 0xF},
+		{"zero signed -> 0xC", decimal.Zero, false, 0xC},
+		{"zero unsigned -> 0xF", decimal.Zero, true, 0xF},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			encoded, err := cobolfmt.EncodePacked(tc.d, 1, 0, tc.unsigned)
+			if err != nil {
+				t.Fatalf("EncodePacked: %v", err)
+			}
+			got := encoded[len(encoded)-1] & 0x0F
+			if got != tc.wantNibble {
+				t.Errorf("sign nibble: got 0x%X, want 0x%X", got, tc.wantNibble)
 			}
 		})
 	}

--- a/internal/cobolfmt/zoned.go
+++ b/internal/cobolfmt/zoned.go
@@ -1,0 +1,141 @@
+package cobolfmt
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/shopspring/decimal"
+)
+
+// DecodeZoned decodes an EBCDIC zoned-decimal field (DISPLAY NUMERIC in COBOL).
+//
+// In EBCDIC zoned decimal each byte stores one decimal digit:
+//   - High nibble (zone): 0xF for unsigned digits; 0xC (positive) or 0xD
+//     (negative) on the last byte of a signed field.
+//   - Low nibble (digit): 0–9.
+//
+// Parameters:
+//   - b: raw EBCDIC bytes of the field.
+//   - scale: number of implied decimal digits (V in the PICTURE clause). A
+//     field declared PIC S9(09)V99 has scale=2.
+//   - signed: true when the field carries a sign (PIC S…).
+func DecodeZoned(b []byte, scale int, signed bool) (decimal.Decimal, error) {
+	if len(b) == 0 {
+		return decimal.Zero, nil
+	}
+
+	digits := make([]byte, len(b))
+	negative := false
+
+	for i, byt := range b {
+		hi := byt >> 4
+		lo := byt & 0x0F
+
+		isLast := i == len(b)-1
+		if isLast && signed {
+			switch hi {
+			case 0xC, 0xF: // positive (0xF = unsigned, treat as positive)
+			case 0xD:
+				negative = true
+			default:
+				return decimal.Zero, fmt.Errorf("cobolfmt: zoned: invalid sign nibble 0x%X at byte %d", hi, i)
+			}
+		}
+
+		if lo > 9 {
+			return decimal.Zero, fmt.Errorf("cobolfmt: zoned: invalid digit nibble 0x%X at byte %d", lo, i)
+		}
+		digits[i] = '0' + lo
+	}
+
+	// Build a numeric string and parse.
+	n := len(b)
+	var s string
+	switch {
+	case scale <= 0:
+		s = string(digits)
+	case scale >= n:
+		s = "0." + strings.Repeat("0", scale-n) + string(digits)
+	default:
+		s = string(digits[:n-scale]) + "." + string(digits[n-scale:])
+	}
+
+	d, err := decimal.NewFromString(s)
+	if err != nil {
+		return decimal.Zero, fmt.Errorf("cobolfmt: zoned: %w", err)
+	}
+	if negative {
+		d = d.Neg()
+	}
+	return d, nil
+}
+
+// EncodeZoned encodes a decimal.Decimal into an EBCDIC zoned-decimal field.
+//
+// Parameters:
+//   - d: value to encode.
+//   - n: total number of digits (= byte width of the field).
+//   - scale: implied decimal digits (V in PICTURE clause).
+//   - signed: true when the field carries a sign (PIC S…).
+//
+// The encoded value is truncated / zero-padded on the left to exactly n digits.
+// Callers are responsible for not passing a value that overflows the field width.
+func EncodeZoned(d decimal.Decimal, n, scale int, signed bool) ([]byte, error) {
+	if n <= 0 {
+		return nil, fmt.Errorf("cobolfmt: zoned: field width must be > 0")
+	}
+
+	negative := d.IsNegative()
+	if negative {
+		d = d.Neg()
+	}
+
+	// Shift the decimal by scale places to work with an integer.
+	shifted := d.Shift(int32(scale))
+	// Truncate any remaining fractional part.
+	shifted = shifted.Floor()
+
+	// Convert to a zero-padded digit string of exactly n chars.
+	raw := shifted.String()
+	// raw may contain a decimal point if scale==0 and d had fractional part;
+	// strip any decimal portion.
+	if idx := strings.IndexByte(raw, '.'); idx >= 0 {
+		raw = raw[:idx]
+	}
+	if len(raw) < n {
+		raw = strings.Repeat("0", n-len(raw)) + raw
+	} else if len(raw) > n {
+		raw = raw[len(raw)-n:] // left-truncate (overflow)
+	}
+
+	out := make([]byte, n)
+	for i := 0; i < n; i++ {
+		digit := raw[i] - '0'
+		isLast := i == n-1
+		if isLast && signed {
+			if negative {
+				out[i] = 0xD0 | digit // negative sign nibble
+			} else {
+				out[i] = 0xC0 | digit // positive sign nibble
+			}
+		} else {
+			out[i] = 0xF0 | digit // unsigned zone nibble
+		}
+	}
+	return out, nil
+}
+
+// DecodeZonedUint is a convenience wrapper that decodes an unsigned zoned field
+// (PIC 9(n)) into an int64.
+func DecodeZonedUint(b []byte) (int64, error) {
+	d, err := DecodeZoned(b, 0, false)
+	if err != nil {
+		return 0, err
+	}
+	return d.IntPart(), nil
+}
+
+// EncodeZonedUint encodes a non-negative integer into a unsigned zoned field.
+func EncodeZonedUint(v int64, n int) ([]byte, error) {
+	return EncodeZoned(decimal.NewFromInt(v), n, 0, false)
+}

--- a/internal/cobolfmt/zoned_test.go
+++ b/internal/cobolfmt/zoned_test.go
@@ -1,0 +1,187 @@
+package cobolfmt_test
+
+import (
+	"testing"
+
+	"github.com/aws-samples/aws-mainframe-modernization-carddemo/internal/cobolfmt"
+	"github.com/shopspring/decimal"
+)
+
+func TestDecodeZoned(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   []byte
+		scale   int
+		signed  bool
+		want    string // decimal string representation
+		wantErr bool
+	}{
+		{
+			name:   "unsigned zero",
+			input:  []byte{0xF0},
+			scale:  0,
+			signed: false,
+			want:   "0",
+		},
+		{
+			name:   "unsigned 123",
+			input:  []byte{0xF1, 0xF2, 0xF3},
+			scale:  0,
+			signed: false,
+			want:   "123",
+		},
+		{
+			name:   "positive signed with C zone",
+			input:  []byte{0xF1, 0xF9, 0xF4, 0xC0}, // 1940 with positive sign on last nibble
+			scale:  2,
+			signed: true,
+			want:   "19.40",
+		},
+		{
+			name:   "negative signed with D zone",
+			input:  []byte{0xF0, 0xF5, 0xD0}, // -50 with scale 2 = -0.50
+			scale:  2,
+			signed: true,
+			want:   "-0.50",
+		},
+		{
+			name:   "S9(10)V99 positive 194.00 from acctdata",
+			input:  []byte{0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF1, 0xF9, 0xF4, 0xF0, 0xC0},
+			scale:  2,
+			signed: true,
+			want:   "194.00",
+		},
+		{
+			name:   "unsigned F zone treated as positive",
+			input:  []byte{0xF4, 0xF2, 0xF0}, // 420 unsigned, scale 2 = 4.20
+			scale:  2,
+			signed: false,
+			want:   "4.20",
+		},
+		{
+			name:   "positive with F zone on last byte",
+			input:  []byte{0xF1, 0xF2, 0xF3}, // unsigned field
+			scale:  0,
+			signed: false,
+			want:   "123",
+		},
+		{
+			name:    "invalid digit nibble",
+			input:   []byte{0xFA},
+			scale:   0,
+			signed:  false,
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := cobolfmt.DecodeZoned(tc.input, tc.scale, tc.signed)
+			if tc.wantErr {
+				if err == nil {
+					t.Errorf("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			want, _ := decimal.NewFromString(tc.want)
+			if !got.Equal(want) {
+				t.Errorf("got %s, want %s", got, want)
+			}
+		})
+	}
+}
+
+func TestEncodeZonedRoundTrip(t *testing.T) {
+	tests := []struct {
+		name   string
+		value  string
+		n      int
+		scale  int
+		signed bool
+	}{
+		{"unsigned 0", "0", 3, 0, false},
+		{"unsigned 123", "123", 3, 0, false},
+		{"positive 194.00", "194.00", 12, 2, true},
+		{"positive 202.00", "202.00", 12, 2, true},
+		{"negative 0.50", "-0.50", 3, 2, true},
+		{"negative 1234.56", "-1234.56", 6, 2, true},
+		{"zero signed", "0.00", 11, 2, true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			d, err := decimal.NewFromString(tc.value)
+			if err != nil {
+				t.Fatalf("invalid decimal %q: %v", tc.value, err)
+			}
+
+			encoded, err := cobolfmt.EncodeZoned(d, tc.n, tc.scale, tc.signed)
+			if err != nil {
+				t.Fatalf("EncodeZoned: %v", err)
+			}
+			if len(encoded) != tc.n {
+				t.Fatalf("encoded length: got %d, want %d", len(encoded), tc.n)
+			}
+
+			decoded, err := cobolfmt.DecodeZoned(encoded, tc.scale, tc.signed)
+			if err != nil {
+				t.Fatalf("DecodeZoned: %v", err)
+			}
+
+			if !decoded.Equal(d) {
+				t.Errorf("round-trip mismatch: got %s, want %s", decoded, d)
+			}
+		})
+	}
+}
+
+func TestDecodeZonedUint(t *testing.T) {
+	tests := []struct {
+		input []byte
+		want  int64
+	}{
+		{[]byte{0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF1}, 1},
+		{[]byte{0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF9}, 9},
+		{[]byte{0xF9, 0xF9, 0xF9}, 999},
+	}
+
+	for _, tc := range tests {
+		got, err := cobolfmt.DecodeZonedUint(tc.input)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got != tc.want {
+			t.Errorf("got %d, want %d", got, tc.want)
+		}
+	}
+}
+
+func TestEncodeZonedUint(t *testing.T) {
+	tests := []struct {
+		val  int64
+		n    int
+		want []byte
+	}{
+		{1, 11, []byte{0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF0, 0xF1}},
+		{999, 3, []byte{0xF9, 0xF9, 0xF9}},
+		{0, 1, []byte{0xF0}},
+	}
+
+	for _, tc := range tests {
+		got, err := cobolfmt.EncodeZonedUint(tc.val, tc.n)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(got) != len(tc.want) {
+			t.Fatalf("length: got %d, want %d", len(got), len(tc.want))
+		}
+		for i := range got {
+			if got[i] != tc.want[i] {
+				t.Errorf("byte[%d]: got 0x%02X, want 0x%02X", i, got[i], tc.want[i])
+			}
+		}
+	}
+}

--- a/internal/domain/account.go
+++ b/internal/domain/account.go
@@ -1,0 +1,182 @@
+package domain
+
+import (
+	"fmt"
+
+	"github.com/aws-samples/aws-mainframe-modernization-carddemo/internal/cobolfmt"
+	"github.com/shopspring/decimal"
+)
+
+// AccountRecord is the Go port of ACCOUNT-RECORD (CVACT01Y.cpy, 300 bytes).
+//
+// COBOL layout:
+//
+//	05 ACCT-ID                PIC 9(11)       offset   0 len 11
+//	05 ACCT-ACTIVE-STATUS     PIC X(01)       offset  11 len  1
+//	05 ACCT-CURR-BAL          PIC S9(10)V99   offset  12 len 12
+//	05 ACCT-CREDIT-LIMIT      PIC S9(10)V99   offset  24 len 12
+//	05 ACCT-CASH-CREDIT-LIMIT PIC S9(10)V99   offset  36 len 12
+//	05 ACCT-OPEN-DATE         PIC X(10)       offset  48 len 10
+//	05 ACCT-EXPIRAION-DATE    PIC X(10)       offset  58 len 10
+//	05 ACCT-REISSUE-DATE      PIC X(10)       offset  68 len 10
+//	05 ACCT-CURR-CYC-CREDIT   PIC S9(10)V99   offset  78 len 12
+//	05 ACCT-CURR-CYC-DEBIT    PIC S9(10)V99   offset  90 len 12
+//	05 ACCT-ADDR-ZIP          PIC X(10)       offset 102 len 10
+//	05 ACCT-GROUP-ID          PIC X(10)       offset 112 len 10
+//	05 FILLER                 PIC X(178)      offset 122 len 178
+type AccountRecord struct {
+	// AcctID is the account identifier (PIC 9(11)).
+	AcctID int64 `cobol:"ACCT-ID,0,11,zoned_uint"`
+	// AcctActiveStatus is 'Y' or 'N' (PIC X(01)).
+	AcctActiveStatus string `cobol:"ACCT-ACTIVE-STATUS,11,1,alpha"`
+	// AcctCurrBal is the current balance (PIC S9(10)V99).
+	AcctCurrBal decimal.Decimal `cobol:"ACCT-CURR-BAL,12,12,zoned_s2"`
+	// AcctCreditLimit is the credit limit (PIC S9(10)V99).
+	AcctCreditLimit decimal.Decimal `cobol:"ACCT-CREDIT-LIMIT,24,12,zoned_s2"`
+	// AcctCashCreditLimit is the cash credit limit (PIC S9(10)V99).
+	AcctCashCreditLimit decimal.Decimal `cobol:"ACCT-CASH-CREDIT-LIMIT,36,12,zoned_s2"`
+	// AcctOpenDate is the account open date YYYY-MM-DD (PIC X(10)).
+	AcctOpenDate string `cobol:"ACCT-OPEN-DATE,48,10,alpha"`
+	// AcctExpirationDate is the card expiration date YYYY-MM-DD (PIC X(10)).
+	AcctExpirationDate string `cobol:"ACCT-EXPIRAION-DATE,58,10,alpha"`
+	// AcctReissueDate is the reissue date YYYY-MM-DD (PIC X(10)).
+	AcctReissueDate string `cobol:"ACCT-REISSUE-DATE,68,10,alpha"`
+	// AcctCurrCycCredit is current cycle credits (PIC S9(10)V99).
+	AcctCurrCycCredit decimal.Decimal `cobol:"ACCT-CURR-CYC-CREDIT,78,12,zoned_s2"`
+	// AcctCurrCycDebit is current cycle debits (PIC S9(10)V99).
+	AcctCurrCycDebit decimal.Decimal `cobol:"ACCT-CURR-CYC-DEBIT,90,12,zoned_s2"`
+	// AcctAddrZip is the account ZIP code (PIC X(10)).
+	AcctAddrZip string `cobol:"ACCT-ADDR-ZIP,102,10,alpha"`
+	// AcctGroupID is the account group identifier (PIC X(10)).
+	AcctGroupID string `cobol:"ACCT-GROUP-ID,112,10,alpha"`
+}
+
+// AccountRecordLen is the fixed length of an ACCOUNT-RECORD in bytes.
+const AccountRecordLen = 300
+
+// DecodeAccountRecord decodes one 300-byte EBCDIC record into an AccountRecord.
+func DecodeAccountRecord(b []byte) (*AccountRecord, error) {
+	if len(b) < AccountRecordLen {
+		return nil, fmt.Errorf("domain: account: record too short: got %d, want %d", len(b), AccountRecordLen)
+	}
+	b = b[:AccountRecordLen]
+
+	var r AccountRecord
+	var err error
+
+	if r.AcctID, err = cobolfmt.DecodeZonedUint(b[0:11]); err != nil {
+		return nil, fmt.Errorf("domain: account: ACCT-ID: %w", err)
+	}
+	if r.AcctActiveStatus, err = cobolfmt.DecodeEBCDICTrimmed(b[11:12]); err != nil {
+		return nil, fmt.Errorf("domain: account: ACCT-ACTIVE-STATUS: %w", err)
+	}
+	if r.AcctCurrBal, err = cobolfmt.DecodeZoned(b[12:24], 2, true); err != nil {
+		return nil, fmt.Errorf("domain: account: ACCT-CURR-BAL: %w", err)
+	}
+	if r.AcctCreditLimit, err = cobolfmt.DecodeZoned(b[24:36], 2, true); err != nil {
+		return nil, fmt.Errorf("domain: account: ACCT-CREDIT-LIMIT: %w", err)
+	}
+	if r.AcctCashCreditLimit, err = cobolfmt.DecodeZoned(b[36:48], 2, true); err != nil {
+		return nil, fmt.Errorf("domain: account: ACCT-CASH-CREDIT-LIMIT: %w", err)
+	}
+	if r.AcctOpenDate, err = cobolfmt.DecodeEBCDICTrimmed(b[48:58]); err != nil {
+		return nil, fmt.Errorf("domain: account: ACCT-OPEN-DATE: %w", err)
+	}
+	if r.AcctExpirationDate, err = cobolfmt.DecodeEBCDICTrimmed(b[58:68]); err != nil {
+		return nil, fmt.Errorf("domain: account: ACCT-EXPIRAION-DATE: %w", err)
+	}
+	if r.AcctReissueDate, err = cobolfmt.DecodeEBCDICTrimmed(b[68:78]); err != nil {
+		return nil, fmt.Errorf("domain: account: ACCT-REISSUE-DATE: %w", err)
+	}
+	if r.AcctCurrCycCredit, err = cobolfmt.DecodeZoned(b[78:90], 2, true); err != nil {
+		return nil, fmt.Errorf("domain: account: ACCT-CURR-CYC-CREDIT: %w", err)
+	}
+	if r.AcctCurrCycDebit, err = cobolfmt.DecodeZoned(b[90:102], 2, true); err != nil {
+		return nil, fmt.Errorf("domain: account: ACCT-CURR-CYC-DEBIT: %w", err)
+	}
+	if r.AcctAddrZip, err = cobolfmt.DecodeEBCDICTrimmed(b[102:112]); err != nil {
+		return nil, fmt.Errorf("domain: account: ACCT-ADDR-ZIP: %w", err)
+	}
+	if r.AcctGroupID, err = cobolfmt.DecodeEBCDICTrimmed(b[112:122]); err != nil {
+		return nil, fmt.Errorf("domain: account: ACCT-GROUP-ID: %w", err)
+	}
+
+	return &r, nil
+}
+
+// Encode serialises an AccountRecord back to its 300-byte EBCDIC representation.
+func (r *AccountRecord) Encode() ([]byte, error) {
+	out := make([]byte, AccountRecordLen)
+
+	fid, err := cobolfmt.EncodeZonedUint(r.AcctID, 11)
+	if err != nil {
+		return nil, fmt.Errorf("domain: account: ACCT-ID: %w", err)
+	}
+	copy(out[0:11], fid)
+
+	fstatus, err := cobolfmt.EncodeEBCDIC(cobolfmt.PadRight(r.AcctActiveStatus, 1), 1)
+	if err != nil {
+		return nil, fmt.Errorf("domain: account: ACCT-ACTIVE-STATUS: %w", err)
+	}
+	copy(out[11:12], fstatus)
+
+	for _, enc := range []struct {
+		val    decimal.Decimal
+		offset int
+		label  string
+	}{
+		{r.AcctCurrBal, 12, "ACCT-CURR-BAL"},
+		{r.AcctCreditLimit, 24, "ACCT-CREDIT-LIMIT"},
+		{r.AcctCashCreditLimit, 36, "ACCT-CASH-CREDIT-LIMIT"},
+		{r.AcctCurrCycCredit, 78, "ACCT-CURR-CYC-CREDIT"},
+		{r.AcctCurrCycDebit, 90, "ACCT-CURR-CYC-DEBIT"},
+	} {
+		fb, ferr := cobolfmt.EncodeZoned(enc.val, 12, 2, true)
+		if ferr != nil {
+			return nil, fmt.Errorf("domain: account: %s: %w", enc.label, ferr)
+		}
+		copy(out[enc.offset:enc.offset+12], fb)
+	}
+
+	for _, enc := range []struct {
+		val    string
+		offset int
+		length int
+		label  string
+	}{
+		{r.AcctOpenDate, 48, 10, "ACCT-OPEN-DATE"},
+		{r.AcctExpirationDate, 58, 10, "ACCT-EXPIRAION-DATE"},
+		{r.AcctReissueDate, 68, 10, "ACCT-REISSUE-DATE"},
+		{r.AcctAddrZip, 102, 10, "ACCT-ADDR-ZIP"},
+		{r.AcctGroupID, 112, 10, "ACCT-GROUP-ID"},
+	} {
+		fb, ferr := cobolfmt.EncodeEBCDIC(cobolfmt.PadRight(enc.val, enc.length), enc.length)
+		if ferr != nil {
+			return nil, fmt.Errorf("domain: account: %s: %w", enc.label, ferr)
+		}
+		copy(out[enc.offset:enc.offset+enc.length], fb)
+	}
+
+	// FILLER (bytes 122-299) stays as zero / EBCDIC spaces.
+	filler := cobolfmt.EBCDICSpacePad(178)
+	copy(out[122:300], filler)
+
+	return out, nil
+}
+
+// DecodeAccountRecords reads all AccountRecords from a flat fixed-length binary file.
+func DecodeAccountRecords(data []byte) ([]*AccountRecord, error) {
+	if len(data)%AccountRecordLen != 0 {
+		return nil, fmt.Errorf("domain: account: data length %d is not a multiple of %d", len(data), AccountRecordLen)
+	}
+	count := len(data) / AccountRecordLen
+	records := make([]*AccountRecord, 0, count)
+	for i := 0; i < count; i++ {
+		rec, err := DecodeAccountRecord(data[i*AccountRecordLen : (i+1)*AccountRecordLen])
+		if err != nil {
+			return nil, fmt.Errorf("domain: account: record %d: %w", i, err)
+		}
+		records = append(records, rec)
+	}
+	return records, nil
+}

--- a/internal/domain/card.go
+++ b/internal/domain/card.go
@@ -1,0 +1,209 @@
+package domain
+
+import (
+	"fmt"
+
+	"github.com/aws-samples/aws-mainframe-modernization-carddemo/internal/cobolfmt"
+)
+
+// CardRecord is the Go port of CARD-RECORD (CVACT02Y.cpy, 150 bytes).
+//
+// COBOL layout:
+//
+//	05 CARD-NUM             PIC X(16)   offset   0 len 16
+//	05 CARD-ACCT-ID         PIC 9(11)   offset  16 len 11
+//	05 CARD-CVV-CD          PIC 9(03)   offset  27 len  3
+//	05 CARD-EMBOSSED-NAME   PIC X(50)   offset  30 len 50
+//	05 CARD-EXPIRAION-DATE  PIC X(10)   offset  80 len 10
+//	05 CARD-ACTIVE-STATUS   PIC X(01)   offset  90 len  1
+//	05 FILLER               PIC X(59)   offset  91 len 59
+type CardRecord struct {
+	// CardNum is the 16-digit card number (PIC X(16)).
+	CardNum string `cobol:"CARD-NUM,0,16,alpha"`
+	// CardAcctID is the account ID linked to the card (PIC 9(11)).
+	CardAcctID int64 `cobol:"CARD-ACCT-ID,16,11,zoned_uint"`
+	// CardCVVCode is the CVV security code (PIC 9(03)).
+	CardCVVCode int64 `cobol:"CARD-CVV-CD,27,3,zoned_uint"`
+	// CardEmbossedName is the name on the card face (PIC X(50)).
+	CardEmbossedName string `cobol:"CARD-EMBOSSED-NAME,30,50,alpha"`
+	// CardExpirationDate is the expiration date YYYY-MM-DD (PIC X(10)).
+	CardExpirationDate string `cobol:"CARD-EXPIRAION-DATE,80,10,alpha"`
+	// CardActiveStatus is 'Y' or 'N' (PIC X(01)).
+	CardActiveStatus string `cobol:"CARD-ACTIVE-STATUS,90,1,alpha"`
+}
+
+// CardRecordLen is the fixed length of a CARD-RECORD in bytes.
+const CardRecordLen = 150
+
+// DecodeCardRecord decodes one 150-byte EBCDIC record into a CardRecord.
+func DecodeCardRecord(b []byte) (*CardRecord, error) {
+	if len(b) < CardRecordLen {
+		return nil, fmt.Errorf("domain: card: record too short: got %d, want %d", len(b), CardRecordLen)
+	}
+	b = b[:CardRecordLen]
+
+	var r CardRecord
+	var err error
+
+	if r.CardNum, err = cobolfmt.DecodeEBCDICTrimmed(b[0:16]); err != nil {
+		return nil, fmt.Errorf("domain: card: CARD-NUM: %w", err)
+	}
+	if r.CardAcctID, err = cobolfmt.DecodeZonedUint(b[16:27]); err != nil {
+		return nil, fmt.Errorf("domain: card: CARD-ACCT-ID: %w", err)
+	}
+	if r.CardCVVCode, err = cobolfmt.DecodeZonedUint(b[27:30]); err != nil {
+		return nil, fmt.Errorf("domain: card: CARD-CVV-CD: %w", err)
+	}
+	if r.CardEmbossedName, err = cobolfmt.DecodeEBCDICTrimmed(b[30:80]); err != nil {
+		return nil, fmt.Errorf("domain: card: CARD-EMBOSSED-NAME: %w", err)
+	}
+	if r.CardExpirationDate, err = cobolfmt.DecodeEBCDICTrimmed(b[80:90]); err != nil {
+		return nil, fmt.Errorf("domain: card: CARD-EXPIRAION-DATE: %w", err)
+	}
+	if r.CardActiveStatus, err = cobolfmt.DecodeEBCDICTrimmed(b[90:91]); err != nil {
+		return nil, fmt.Errorf("domain: card: CARD-ACTIVE-STATUS: %w", err)
+	}
+
+	return &r, nil
+}
+
+// Encode serialises a CardRecord back to its 150-byte EBCDIC representation.
+func (r *CardRecord) Encode() ([]byte, error) {
+	out := make([]byte, CardRecordLen)
+
+	for _, enc := range []struct {
+		val    string
+		offset int
+		length int
+		label  string
+	}{
+		{r.CardNum, 0, 16, "CARD-NUM"},
+		{r.CardEmbossedName, 30, 50, "CARD-EMBOSSED-NAME"},
+		{r.CardExpirationDate, 80, 10, "CARD-EXPIRAION-DATE"},
+		{r.CardActiveStatus, 90, 1, "CARD-ACTIVE-STATUS"},
+	} {
+		fb, ferr := cobolfmt.EncodeEBCDIC(cobolfmt.PadRight(enc.val, enc.length), enc.length)
+		if ferr != nil {
+			return nil, fmt.Errorf("domain: card: %s: %w", enc.label, ferr)
+		}
+		copy(out[enc.offset:enc.offset+enc.length], fb)
+	}
+
+	fid, err := cobolfmt.EncodeZonedUint(r.CardAcctID, 11)
+	if err != nil {
+		return nil, fmt.Errorf("domain: card: CARD-ACCT-ID: %w", err)
+	}
+	copy(out[16:27], fid)
+
+	fcvv, err := cobolfmt.EncodeZonedUint(r.CardCVVCode, 3)
+	if err != nil {
+		return nil, fmt.Errorf("domain: card: CARD-CVV-CD: %w", err)
+	}
+	copy(out[27:30], fcvv)
+
+	copy(out[91:150], cobolfmt.EBCDICSpacePad(59))
+	return out, nil
+}
+
+// DecodeCardRecords reads all CardRecords from a flat fixed-length binary file.
+func DecodeCardRecords(data []byte) ([]*CardRecord, error) {
+	if len(data)%CardRecordLen != 0 {
+		return nil, fmt.Errorf("domain: card: data length %d is not a multiple of %d", len(data), CardRecordLen)
+	}
+	count := len(data) / CardRecordLen
+	records := make([]*CardRecord, 0, count)
+	for i := 0; i < count; i++ {
+		rec, err := DecodeCardRecord(data[i*CardRecordLen : (i+1)*CardRecordLen])
+		if err != nil {
+			return nil, fmt.Errorf("domain: card: record %d: %w", i, err)
+		}
+		records = append(records, rec)
+	}
+	return records, nil
+}
+
+// CardXrefRecord is the Go port of CARD-XREF-RECORD (CVACT03Y.cpy, 50 bytes).
+//
+// COBOL layout:
+//
+//	05 XREF-CARD-NUM  PIC X(16)  offset  0 len 16
+//	05 XREF-CUST-ID   PIC 9(09)  offset 16 len  9
+//	05 XREF-ACCT-ID   PIC 9(11)  offset 25 len 11
+//	05 FILLER         PIC X(14)  offset 36 len 14
+type CardXrefRecord struct {
+	// XrefCardNum is the card number (PIC X(16)).
+	XrefCardNum string `cobol:"XREF-CARD-NUM,0,16,alpha"`
+	// XrefCustID is the customer ID (PIC 9(09)).
+	XrefCustID int64 `cobol:"XREF-CUST-ID,16,9,zoned_uint"`
+	// XrefAcctID is the account ID (PIC 9(11)).
+	XrefAcctID int64 `cobol:"XREF-ACCT-ID,25,11,zoned_uint"`
+}
+
+// CardXrefRecordLen is the fixed length of a CARD-XREF-RECORD in bytes.
+const CardXrefRecordLen = 50
+
+// DecodeCardXrefRecord decodes one 50-byte EBCDIC record into a CardXrefRecord.
+func DecodeCardXrefRecord(b []byte) (*CardXrefRecord, error) {
+	if len(b) < CardXrefRecordLen {
+		return nil, fmt.Errorf("domain: cardxref: record too short: got %d, want %d", len(b), CardXrefRecordLen)
+	}
+	b = b[:CardXrefRecordLen]
+
+	var r CardXrefRecord
+	var err error
+
+	if r.XrefCardNum, err = cobolfmt.DecodeEBCDICTrimmed(b[0:16]); err != nil {
+		return nil, fmt.Errorf("domain: cardxref: XREF-CARD-NUM: %w", err)
+	}
+	if r.XrefCustID, err = cobolfmt.DecodeZonedUint(b[16:25]); err != nil {
+		return nil, fmt.Errorf("domain: cardxref: XREF-CUST-ID: %w", err)
+	}
+	if r.XrefAcctID, err = cobolfmt.DecodeZonedUint(b[25:36]); err != nil {
+		return nil, fmt.Errorf("domain: cardxref: XREF-ACCT-ID: %w", err)
+	}
+
+	return &r, nil
+}
+
+// Encode serialises a CardXrefRecord back to its 50-byte EBCDIC representation.
+func (r *CardXrefRecord) Encode() ([]byte, error) {
+	out := make([]byte, CardXrefRecordLen)
+
+	fnum, err := cobolfmt.EncodeEBCDIC(cobolfmt.PadRight(r.XrefCardNum, 16), 16)
+	if err != nil {
+		return nil, fmt.Errorf("domain: cardxref: XREF-CARD-NUM: %w", err)
+	}
+	copy(out[0:16], fnum)
+
+	fcust, err := cobolfmt.EncodeZonedUint(r.XrefCustID, 9)
+	if err != nil {
+		return nil, fmt.Errorf("domain: cardxref: XREF-CUST-ID: %w", err)
+	}
+	copy(out[16:25], fcust)
+
+	facct, err := cobolfmt.EncodeZonedUint(r.XrefAcctID, 11)
+	if err != nil {
+		return nil, fmt.Errorf("domain: cardxref: XREF-ACCT-ID: %w", err)
+	}
+	copy(out[25:36], facct)
+
+	copy(out[36:50], cobolfmt.EBCDICSpacePad(14))
+	return out, nil
+}
+
+// DecodeCardXrefRecords reads all CardXrefRecords from a flat fixed-length binary file.
+func DecodeCardXrefRecords(data []byte) ([]*CardXrefRecord, error) {
+	if len(data)%CardXrefRecordLen != 0 {
+		return nil, fmt.Errorf("domain: cardxref: data length %d is not a multiple of %d", len(data), CardXrefRecordLen)
+	}
+	count := len(data) / CardXrefRecordLen
+	records := make([]*CardXrefRecord, 0, count)
+	for i := 0; i < count; i++ {
+		rec, err := DecodeCardXrefRecord(data[i*CardXrefRecordLen : (i+1)*CardXrefRecordLen])
+		if err != nil {
+			return nil, fmt.Errorf("domain: cardxref: record %d: %w", i, err)
+		}
+		records = append(records, rec)
+	}
+	return records, nil
+}

--- a/internal/domain/customer.go
+++ b/internal/domain/customer.go
@@ -1,0 +1,198 @@
+package domain
+
+import (
+	"fmt"
+
+	"github.com/aws-samples/aws-mainframe-modernization-carddemo/internal/cobolfmt"
+)
+
+// CustomerRecord is the Go port of CUSTOMER-RECORD (CVCUS01Y.cpy / CUSTREC.cpy, 500 bytes).
+//
+// COBOL layout (CVCUS01Y.cpy):
+//
+//	05 CUST-ID                PIC 9(09)    offset   0 len   9
+//	05 CUST-FIRST-NAME        PIC X(25)    offset   9 len  25
+//	05 CUST-MIDDLE-NAME       PIC X(25)    offset  34 len  25
+//	05 CUST-LAST-NAME         PIC X(25)    offset  59 len  25
+//	05 CUST-ADDR-LINE-1       PIC X(50)    offset  84 len  50
+//	05 CUST-ADDR-LINE-2       PIC X(50)    offset 134 len  50
+//	05 CUST-ADDR-LINE-3       PIC X(50)    offset 184 len  50
+//	05 CUST-ADDR-STATE-CD     PIC X(02)    offset 234 len   2
+//	05 CUST-ADDR-COUNTRY-CD   PIC X(03)    offset 236 len   3
+//	05 CUST-ADDR-ZIP          PIC X(10)    offset 239 len  10
+//	05 CUST-PHONE-NUM-1       PIC X(15)    offset 249 len  15
+//	05 CUST-PHONE-NUM-2       PIC X(15)    offset 264 len  15
+//	05 CUST-SSN               PIC 9(09)    offset 279 len   9
+//	05 CUST-GOVT-ISSUED-ID    PIC X(20)    offset 288 len  20
+//	05 CUST-DOB-YYYY-MM-DD    PIC X(10)    offset 308 len  10
+//	05 CUST-EFT-ACCOUNT-ID    PIC X(10)    offset 318 len  10
+//	05 CUST-PRI-CARD-HOLDER-IND PIC X(01)  offset 328 len   1
+//	05 CUST-FICO-CREDIT-SCORE PIC 9(03)    offset 329 len   3
+//	05 FILLER                 PIC X(168)   offset 332 len 168
+type CustomerRecord struct {
+	// CustID is the customer identifier (PIC 9(09)).
+	CustID int64 `cobol:"CUST-ID,0,9,zoned_uint"`
+	// CustFirstName is the customer's first name (PIC X(25)).
+	CustFirstName string `cobol:"CUST-FIRST-NAME,9,25,alpha"`
+	// CustMiddleName is the customer's middle name (PIC X(25)).
+	CustMiddleName string `cobol:"CUST-MIDDLE-NAME,34,25,alpha"`
+	// CustLastName is the customer's last name (PIC X(25)).
+	CustLastName string `cobol:"CUST-LAST-NAME,59,25,alpha"`
+	// CustAddrLine1 is address line 1 (PIC X(50)).
+	CustAddrLine1 string `cobol:"CUST-ADDR-LINE-1,84,50,alpha"`
+	// CustAddrLine2 is address line 2 (PIC X(50)).
+	CustAddrLine2 string `cobol:"CUST-ADDR-LINE-2,134,50,alpha"`
+	// CustAddrLine3 is address line 3 (PIC X(50)).
+	CustAddrLine3 string `cobol:"CUST-ADDR-LINE-3,184,50,alpha"`
+	// CustAddrStateCode is the US state code (PIC X(02)).
+	CustAddrStateCode string `cobol:"CUST-ADDR-STATE-CD,234,2,alpha"`
+	// CustAddrCountryCode is the country code (PIC X(03)).
+	CustAddrCountryCode string `cobol:"CUST-ADDR-COUNTRY-CD,236,3,alpha"`
+	// CustAddrZip is the ZIP/postal code (PIC X(10)).
+	CustAddrZip string `cobol:"CUST-ADDR-ZIP,239,10,alpha"`
+	// CustPhoneNum1 is primary phone number (PIC X(15)).
+	CustPhoneNum1 string `cobol:"CUST-PHONE-NUM-1,249,15,alpha"`
+	// CustPhoneNum2 is secondary phone number (PIC X(15)).
+	CustPhoneNum2 string `cobol:"CUST-PHONE-NUM-2,264,15,alpha"`
+	// CustSSN is the Social Security Number (PIC 9(09)).
+	CustSSN int64 `cobol:"CUST-SSN,279,9,zoned_uint"`
+	// CustGovtIssuedID is a government-issued ID number (PIC X(20)).
+	CustGovtIssuedID string `cobol:"CUST-GOVT-ISSUED-ID,288,20,alpha"`
+	// CustDOB is the date of birth YYYY-MM-DD (PIC X(10)).
+	CustDOB string `cobol:"CUST-DOB-YYYY-MM-DD,308,10,alpha"`
+	// CustEFTAccountID is the EFT account ID (PIC X(10)).
+	CustEFTAccountID string `cobol:"CUST-EFT-ACCOUNT-ID,318,10,alpha"`
+	// CustPriCardHolderInd is 'Y' if primary card holder (PIC X(01)).
+	CustPriCardHolderInd string `cobol:"CUST-PRI-CARD-HOLDER-IND,328,1,alpha"`
+	// CustFICOCreditScore is the FICO credit score (PIC 9(03)).
+	CustFICOCreditScore int64 `cobol:"CUST-FICO-CREDIT-SCORE,329,3,zoned_uint"`
+}
+
+// CustomerRecordLen is the fixed length of a CUSTOMER-RECORD in bytes.
+const CustomerRecordLen = 500
+
+// DecodeCustomerRecord decodes one 500-byte EBCDIC record into a CustomerRecord.
+func DecodeCustomerRecord(b []byte) (*CustomerRecord, error) {
+	if len(b) < CustomerRecordLen {
+		return nil, fmt.Errorf("domain: customer: record too short: got %d, want %d", len(b), CustomerRecordLen)
+	}
+	b = b[:CustomerRecordLen]
+
+	var r CustomerRecord
+	var err error
+
+	if r.CustID, err = cobolfmt.DecodeZonedUint(b[0:9]); err != nil {
+		return nil, fmt.Errorf("domain: customer: CUST-ID: %w", err)
+	}
+
+	alphaFields := []struct {
+		dst    *string
+		offset int
+		length int
+		label  string
+	}{
+		{&r.CustFirstName, 9, 25, "CUST-FIRST-NAME"},
+		{&r.CustMiddleName, 34, 25, "CUST-MIDDLE-NAME"},
+		{&r.CustLastName, 59, 25, "CUST-LAST-NAME"},
+		{&r.CustAddrLine1, 84, 50, "CUST-ADDR-LINE-1"},
+		{&r.CustAddrLine2, 134, 50, "CUST-ADDR-LINE-2"},
+		{&r.CustAddrLine3, 184, 50, "CUST-ADDR-LINE-3"},
+		{&r.CustAddrStateCode, 234, 2, "CUST-ADDR-STATE-CD"},
+		{&r.CustAddrCountryCode, 236, 3, "CUST-ADDR-COUNTRY-CD"},
+		{&r.CustAddrZip, 239, 10, "CUST-ADDR-ZIP"},
+		{&r.CustPhoneNum1, 249, 15, "CUST-PHONE-NUM-1"},
+		{&r.CustPhoneNum2, 264, 15, "CUST-PHONE-NUM-2"},
+		{&r.CustGovtIssuedID, 288, 20, "CUST-GOVT-ISSUED-ID"},
+		{&r.CustDOB, 308, 10, "CUST-DOB-YYYY-MM-DD"},
+		{&r.CustEFTAccountID, 318, 10, "CUST-EFT-ACCOUNT-ID"},
+		{&r.CustPriCardHolderInd, 328, 1, "CUST-PRI-CARD-HOLDER-IND"},
+	}
+	for _, af := range alphaFields {
+		*af.dst, err = cobolfmt.DecodeEBCDICTrimmed(b[af.offset : af.offset+af.length])
+		if err != nil {
+			return nil, fmt.Errorf("domain: customer: %s: %w", af.label, err)
+		}
+	}
+
+	if r.CustSSN, err = cobolfmt.DecodeZonedUint(b[279:288]); err != nil {
+		return nil, fmt.Errorf("domain: customer: CUST-SSN: %w", err)
+	}
+	if r.CustFICOCreditScore, err = cobolfmt.DecodeZonedUint(b[329:332]); err != nil {
+		return nil, fmt.Errorf("domain: customer: CUST-FICO-CREDIT-SCORE: %w", err)
+	}
+
+	return &r, nil
+}
+
+// Encode serialises a CustomerRecord back to its 500-byte EBCDIC representation.
+func (r *CustomerRecord) Encode() ([]byte, error) {
+	out := make([]byte, CustomerRecordLen)
+
+	fid, err := cobolfmt.EncodeZonedUint(r.CustID, 9)
+	if err != nil {
+		return nil, fmt.Errorf("domain: customer: CUST-ID: %w", err)
+	}
+	copy(out[0:9], fid)
+
+	alphaFields := []struct {
+		val    string
+		offset int
+		length int
+		label  string
+	}{
+		{r.CustFirstName, 9, 25, "CUST-FIRST-NAME"},
+		{r.CustMiddleName, 34, 25, "CUST-MIDDLE-NAME"},
+		{r.CustLastName, 59, 25, "CUST-LAST-NAME"},
+		{r.CustAddrLine1, 84, 50, "CUST-ADDR-LINE-1"},
+		{r.CustAddrLine2, 134, 50, "CUST-ADDR-LINE-2"},
+		{r.CustAddrLine3, 184, 50, "CUST-ADDR-LINE-3"},
+		{r.CustAddrStateCode, 234, 2, "CUST-ADDR-STATE-CD"},
+		{r.CustAddrCountryCode, 236, 3, "CUST-ADDR-COUNTRY-CD"},
+		{r.CustAddrZip, 239, 10, "CUST-ADDR-ZIP"},
+		{r.CustPhoneNum1, 249, 15, "CUST-PHONE-NUM-1"},
+		{r.CustPhoneNum2, 264, 15, "CUST-PHONE-NUM-2"},
+		{r.CustGovtIssuedID, 288, 20, "CUST-GOVT-ISSUED-ID"},
+		{r.CustDOB, 308, 10, "CUST-DOB-YYYY-MM-DD"},
+		{r.CustEFTAccountID, 318, 10, "CUST-EFT-ACCOUNT-ID"},
+		{r.CustPriCardHolderInd, 328, 1, "CUST-PRI-CARD-HOLDER-IND"},
+	}
+	for _, af := range alphaFields {
+		fb, ferr := cobolfmt.EncodeEBCDIC(cobolfmt.PadRight(af.val, af.length), af.length)
+		if ferr != nil {
+			return nil, fmt.Errorf("domain: customer: %s: %w", af.label, ferr)
+		}
+		copy(out[af.offset:af.offset+af.length], fb)
+	}
+
+	fssn, err := cobolfmt.EncodeZonedUint(r.CustSSN, 9)
+	if err != nil {
+		return nil, fmt.Errorf("domain: customer: CUST-SSN: %w", err)
+	}
+	copy(out[279:288], fssn)
+
+	ffico, err := cobolfmt.EncodeZonedUint(r.CustFICOCreditScore, 3)
+	if err != nil {
+		return nil, fmt.Errorf("domain: customer: CUST-FICO-CREDIT-SCORE: %w", err)
+	}
+	copy(out[329:332], ffico)
+
+	copy(out[332:500], cobolfmt.EBCDICSpacePad(168))
+	return out, nil
+}
+
+// DecodeCustomerRecords reads all CustomerRecords from a flat fixed-length binary file.
+func DecodeCustomerRecords(data []byte) ([]*CustomerRecord, error) {
+	if len(data)%CustomerRecordLen != 0 {
+		return nil, fmt.Errorf("domain: customer: data length %d is not a multiple of %d", len(data), CustomerRecordLen)
+	}
+	count := len(data) / CustomerRecordLen
+	records := make([]*CustomerRecord, 0, count)
+	for i := 0; i < count; i++ {
+		rec, err := DecodeCustomerRecord(data[i*CustomerRecordLen : (i+1)*CustomerRecordLen])
+		if err != nil {
+			return nil, fmt.Errorf("domain: customer: record %d: %w", i, err)
+		}
+		records = append(records, rec)
+	}
+	return records, nil
+}

--- a/internal/domain/doc.go
+++ b/internal/domain/doc.go
@@ -1,0 +1,18 @@
+// Package domain holds the CardDemo domain types ported from COBOL copybooks.
+//
+// Each struct maps to a COBOL data-layout (copybook or WORKING-STORAGE section)
+// and carries the same field semantics with Go-idiomatic naming.
+//
+// COBOL copybook → Go struct mapping:
+//
+//	CSUSR01Y.cpy   → UserSec     (user security record, 80 bytes)
+//	CVACT01Y.cpy   → Account     (account master, RAU-38)
+//	CVACT02Y.cpy   → AccountView (account view, RAU-38)
+//	CVACT03Y.cpy   → AccountXref (account cross-reference, RAU-38)
+//	CVCRD01Y.cpy   → CreditCard  (credit-card record, RAU-40)
+//	CVCUS01Y.cpy   → Customer    (customer master, RAU-37)
+//	CVTRA05Y.cpy   → Transaction (transaction record, RAU-41)
+//
+// All monetary fields use github.com/shopspring/decimal (ADR 0007); float64 is banned.
+// Timestamps are stored as Unix seconds (int64) to match the SQLite schema.
+package domain

--- a/internal/domain/export.go
+++ b/internal/domain/export.go
@@ -1,0 +1,797 @@
+package domain
+
+import (
+	"fmt"
+
+	"github.com/aws-samples/aws-mainframe-modernization-carddemo/internal/cobolfmt"
+	"github.com/shopspring/decimal"
+)
+
+// ExportRecord is the Go port of EXPORT-RECORD (CVEXPORT.cpy, 500 bytes).
+//
+// The copybook uses REDEFINES to overlay the 460-byte EXPORT-RECORD-DATA
+// field with five mutually exclusive record types. Only one of Customer,
+// Account, Transaction, CardXref, or Card is non-nil based on RecType.
+//
+// Common header layout:
+//
+//	05 EXPORT-REC-TYPE         PIC X(1)    offset   0 len  1
+//	05 EXPORT-TIMESTAMP        PIC X(26)   offset   1 len 26
+//	05 EXPORT-SEQUENCE-NUM     PIC 9(9)    COMP     offset  27 len  4
+//	05 EXPORT-BRANCH-ID        PIC X(4)    offset  31 len  4
+//	05 EXPORT-REGION-CODE      PIC X(5)    offset  36 len  5
+//	05 EXPORT-RECORD-DATA      PIC X(460)  offset  40 len 460
+type ExportRecord struct {
+	RecType     string // EXPORT-REC-TYPE PIC X(1)
+	Timestamp   string // EXPORT-TIMESTAMP PIC X(26)
+	SequenceNum int64  // EXPORT-SEQUENCE-NUM PIC 9(9) COMP
+	BranchID    string // EXPORT-BRANCH-ID PIC X(4)
+	RegionCode  string // EXPORT-REGION-CODE PIC X(5)
+
+	// Exactly one of the following is non-nil.
+	Customer    *ExportCustomerData
+	Account     *ExportAccountData
+	Transaction *ExportTransactionData
+	CardXref    *ExportCardXrefData
+	Card        *ExportCardData
+}
+
+// ExportCustomerData is the EXPORT-CUSTOMER-DATA REDEFINES (460 bytes, RecType "C").
+//
+// Layout within EXPORT-RECORD-DATA:
+//
+//	10 EXP-CUST-ID                 PIC 9(09) COMP         offset   0 len  4
+//	10 EXP-CUST-FIRST-NAME         PIC X(25)              offset   4 len 25
+//	10 EXP-CUST-MIDDLE-NAME        PIC X(25)              offset  29 len 25
+//	10 EXP-CUST-LAST-NAME          PIC X(25)              offset  54 len 25
+//	10 EXP-CUST-ADDR-LINES (3×50)  PIC X(50)              offset  79 len 150
+//	10 EXP-CUST-ADDR-STATE-CD      PIC X(02)              offset 229 len  2
+//	10 EXP-CUST-ADDR-COUNTRY-CD    PIC X(03)              offset 231 len  3
+//	10 EXP-CUST-ADDR-ZIP           PIC X(10)              offset 234 len 10
+//	10 EXP-CUST-PHONE-NUMS (2×15)  PIC X(15)              offset 244 len 30
+//	10 EXP-CUST-SSN                PIC 9(09)              offset 274 len  9
+//	10 EXP-CUST-GOVT-ISSUED-ID     PIC X(20)              offset 283 len 20
+//	10 EXP-CUST-DOB-YYYY-MM-DD     PIC X(10)              offset 303 len 10
+//	10 EXP-CUST-EFT-ACCOUNT-ID     PIC X(10)              offset 313 len 10
+//	10 EXP-CUST-PRI-CARD-HOLDER-IND PIC X(01)             offset 323 len  1
+//	10 EXP-CUST-FICO-CREDIT-SCORE  PIC 9(03) COMP-3       offset 324 len  2
+//	10 FILLER                      PIC X(134)             offset 326 len 134
+type ExportCustomerData struct {
+	CustID             int64           // PIC 9(09) COMP
+	FirstName          string          // PIC X(25)
+	MiddleName         string          // PIC X(25)
+	LastName           string          // PIC X(25)
+	AddrLine1          string          // PIC X(50) (OCCURS index 1)
+	AddrLine2          string          // PIC X(50) (OCCURS index 2)
+	AddrLine3          string          // PIC X(50) (OCCURS index 3)
+	AddrStateCode      string          // PIC X(02)
+	AddrCountryCode    string          // PIC X(03)
+	AddrZip            string          // PIC X(10)
+	PhoneNum1          string          // PIC X(15) (OCCURS index 1)
+	PhoneNum2          string          // PIC X(15) (OCCURS index 2)
+	SSN                int64           // PIC 9(09) zoned unsigned
+	GovtIssuedID       string          // PIC X(20)
+	DOB                string          // PIC X(10)
+	EFTAccountID       string          // PIC X(10)
+	PriCardHolderInd   string          // PIC X(01)
+	FICOCreditScore    decimal.Decimal // PIC 9(03) COMP-3 (unsigned)
+}
+
+// ExportAccountData is the EXPORT-ACCOUNT-DATA REDEFINES (460 bytes, RecType "A").
+//
+// Layout within EXPORT-RECORD-DATA:
+//
+//	10 EXP-ACCT-ID               PIC 9(11)              offset   0 len 11
+//	10 EXP-ACCT-ACTIVE-STATUS    PIC X(01)              offset  11 len  1
+//	10 EXP-ACCT-CURR-BAL         PIC S9(10)V99 COMP-3   offset  12 len  7
+//	10 EXP-ACCT-CREDIT-LIMIT     PIC S9(10)V99          offset  19 len 12
+//	10 EXP-ACCT-CASH-CREDIT-LIMIT PIC S9(10)V99 COMP-3  offset  31 len  7
+//	10 EXP-ACCT-OPEN-DATE        PIC X(10)              offset  38 len 10
+//	10 EXP-ACCT-EXPIRAION-DATE   PIC X(10)              offset  48 len 10
+//	10 EXP-ACCT-REISSUE-DATE     PIC X(10)              offset  58 len 10
+//	10 EXP-ACCT-CURR-CYC-CREDIT  PIC S9(10)V99          offset  68 len 12
+//	10 EXP-ACCT-CURR-CYC-DEBIT   PIC S9(10)V99 COMP     offset  80 len  8
+//	10 EXP-ACCT-ADDR-ZIP         PIC X(10)              offset  88 len 10
+//	10 EXP-ACCT-GROUP-ID         PIC X(10)              offset  98 len 10
+//	10 FILLER                    PIC X(352)             offset 108 len 352
+type ExportAccountData struct {
+	AcctID           int64           // PIC 9(11) zoned unsigned
+	AcctActiveStatus string          // PIC X(01)
+	AcctCurrBal      decimal.Decimal // PIC S9(10)V99 COMP-3 signed
+	AcctCreditLimit  decimal.Decimal // PIC S9(10)V99 zoned signed
+	AcctCashCredit   decimal.Decimal // PIC S9(10)V99 COMP-3 signed
+	AcctOpenDate     string          // PIC X(10)
+	AcctExpiryDate   string          // PIC X(10)
+	AcctReissueDate  string          // PIC X(10)
+	AcctCurrCycCredit decimal.Decimal // PIC S9(10)V99 zoned signed
+	AcctCurrCycDebit  decimal.Decimal // PIC S9(10)V99 COMP signed scale=2
+	AcctAddrZip      string          // PIC X(10)
+	AcctGroupID      string          // PIC X(10)
+}
+
+// ExportTransactionData is the EXPORT-TRANSACTION-DATA REDEFINES (460 bytes, RecType "T").
+//
+// Layout within EXPORT-RECORD-DATA:
+//
+//	10 EXP-TRAN-ID               PIC X(16)              offset   0 len 16
+//	10 EXP-TRAN-TYPE-CD          PIC X(02)              offset  16 len  2
+//	10 EXP-TRAN-CAT-CD           PIC 9(04)              offset  18 len  4
+//	10 EXP-TRAN-SOURCE           PIC X(10)              offset  22 len 10
+//	10 EXP-TRAN-DESC             PIC X(100)             offset  32 len 100
+//	10 EXP-TRAN-AMT              PIC S9(09)V99 COMP-3   offset 132 len  6
+//	10 EXP-TRAN-MERCHANT-ID      PIC 9(09) COMP         offset 138 len  4
+//	10 EXP-TRAN-MERCHANT-NAME    PIC X(50)              offset 142 len 50
+//	10 EXP-TRAN-MERCHANT-CITY    PIC X(50)              offset 192 len 50
+//	10 EXP-TRAN-MERCHANT-ZIP     PIC X(10)              offset 242 len 10
+//	10 EXP-TRAN-CARD-NUM         PIC X(16)              offset 252 len 16
+//	10 EXP-TRAN-ORIG-TS          PIC X(26)              offset 268 len 26
+//	10 EXP-TRAN-PROC-TS          PIC X(26)              offset 294 len 26
+//	10 FILLER                    PIC X(140)             offset 320 len 140
+type ExportTransactionData struct {
+	TranID          string          // PIC X(16)
+	TranTypeCode    string          // PIC X(02)
+	TranCatCode     int64           // PIC 9(04) zoned unsigned
+	TranSource      string          // PIC X(10)
+	TranDesc        string          // PIC X(100)
+	TranAmt         decimal.Decimal // PIC S9(09)V99 COMP-3 signed scale=2
+	TranMerchantID  int64           // PIC 9(09) COMP unsigned
+	MerchantName    string          // PIC X(50)
+	MerchantCity    string          // PIC X(50)
+	MerchantZip     string          // PIC X(10)
+	TranCardNum     string          // PIC X(16)
+	TranOrigTS      string          // PIC X(26)
+	TranProcTS      string          // PIC X(26)
+}
+
+// ExportCardXrefData is the EXPORT-CARD-XREF-DATA REDEFINES (460 bytes, RecType "X").
+//
+// Layout within EXPORT-RECORD-DATA:
+//
+//	10 EXP-XREF-CARD-NUM   PIC X(16)      offset  0 len 16
+//	10 EXP-XREF-CUST-ID    PIC 9(09)      offset 16 len  9
+//	10 EXP-XREF-ACCT-ID    PIC 9(11) COMP offset 25 len  8
+//	10 FILLER              PIC X(427)     offset 33 len 427
+type ExportCardXrefData struct {
+	XrefCardNum string // PIC X(16)
+	XrefCustID  int64  // PIC 9(09) zoned unsigned
+	XrefAcctID  int64  // PIC 9(11) COMP unsigned
+}
+
+// ExportCardData is the EXPORT-CARD-DATA REDEFINES (460 bytes, RecType "D").
+//
+// Layout within EXPORT-RECORD-DATA:
+//
+//	10 EXP-CARD-NUM              PIC X(16)        offset  0 len 16
+//	10 EXP-CARD-ACCT-ID          PIC 9(11) COMP   offset 16 len  8
+//	10 EXP-CARD-CVV-CD           PIC 9(03) COMP   offset 24 len  2
+//	10 EXP-CARD-EMBOSSED-NAME    PIC X(50)         offset 26 len 50
+//	10 EXP-CARD-EXPIRAION-DATE   PIC X(10)         offset 76 len 10
+//	10 EXP-CARD-ACTIVE-STATUS    PIC X(01)         offset 86 len  1
+//	10 FILLER                    PIC X(373)        offset 87 len 373
+type ExportCardData struct {
+	CardNum        string // PIC X(16)
+	CardAcctID     int64  // PIC 9(11) COMP unsigned
+	CardCVVCode    int64  // PIC 9(03) COMP unsigned
+	CardEmbossed   string // PIC X(50)
+	CardExpiryDate string // PIC X(10)
+	CardActive     string // PIC X(01)
+}
+
+// ExportRecordLen is the fixed length of an EXPORT-RECORD in bytes.
+const ExportRecordLen = 500
+
+// exportHeaderLen is the number of bytes before EXPORT-RECORD-DATA.
+const exportHeaderLen = 40
+
+// exportDataLen is the length of the EXPORT-RECORD-DATA section.
+const exportDataLen = 460
+
+// DecodeExportRecord decodes one 500-byte record from the multi-record export file.
+func DecodeExportRecord(b []byte) (*ExportRecord, error) {
+	if len(b) < ExportRecordLen {
+		return nil, fmt.Errorf("domain: export: record too short: got %d, want %d", len(b), ExportRecordLen)
+	}
+	b = b[:ExportRecordLen]
+
+	var r ExportRecord
+	var err error
+
+	if r.RecType, err = cobolfmt.DecodeEBCDICTrimmed(b[0:1]); err != nil {
+		return nil, fmt.Errorf("domain: export: EXPORT-REC-TYPE: %w", err)
+	}
+	if r.Timestamp, err = cobolfmt.DecodeEBCDICTrimmed(b[1:27]); err != nil {
+		return nil, fmt.Errorf("domain: export: EXPORT-TIMESTAMP: %w", err)
+	}
+	r.SequenceNum, err = cobolfmt.DecodeComp(b[27:31], false)
+	if err != nil {
+		return nil, fmt.Errorf("domain: export: EXPORT-SEQUENCE-NUM: %w", err)
+	}
+	if r.BranchID, err = cobolfmt.DecodeEBCDICTrimmed(b[31:35]); err != nil {
+		return nil, fmt.Errorf("domain: export: EXPORT-BRANCH-ID: %w", err)
+	}
+	if r.RegionCode, err = cobolfmt.DecodeEBCDICTrimmed(b[35:40]); err != nil {
+		return nil, fmt.Errorf("domain: export: EXPORT-REGION-CODE: %w", err)
+	}
+
+	data := b[exportHeaderLen:]
+
+	switch r.RecType {
+	case "C":
+		r.Customer, err = decodeExportCustomer(data)
+	case "A":
+		r.Account, err = decodeExportAccount(data)
+	case "T":
+		r.Transaction, err = decodeExportTransaction(data)
+	case "X":
+		r.CardXref, err = decodeExportCardXref(data)
+	case "D":
+		r.Card, err = decodeExportCard(data)
+	default:
+		return nil, fmt.Errorf("domain: export: unknown record type %q", r.RecType)
+	}
+	if err != nil {
+		return nil, fmt.Errorf("domain: export: type %q data: %w", r.RecType, err)
+	}
+
+	return &r, nil
+}
+
+func decodeExportCustomer(d []byte) (*ExportCustomerData, error) {
+	var c ExportCustomerData
+	var err error
+
+	c.CustID, err = cobolfmt.DecodeComp(d[0:4], false)
+	if err != nil {
+		return nil, fmt.Errorf("EXP-CUST-ID: %w", err)
+	}
+	for _, af := range []struct {
+		dst    *string
+		off, n int
+		label  string
+	}{
+		{&c.FirstName, 4, 25, "EXP-CUST-FIRST-NAME"},
+		{&c.MiddleName, 29, 25, "EXP-CUST-MIDDLE-NAME"},
+		{&c.LastName, 54, 25, "EXP-CUST-LAST-NAME"},
+		{&c.AddrLine1, 79, 50, "EXP-CUST-ADDR-LINE(1)"},
+		{&c.AddrLine2, 129, 50, "EXP-CUST-ADDR-LINE(2)"},
+		{&c.AddrLine3, 179, 50, "EXP-CUST-ADDR-LINE(3)"},
+		{&c.AddrStateCode, 229, 2, "EXP-CUST-ADDR-STATE-CD"},
+		{&c.AddrCountryCode, 231, 3, "EXP-CUST-ADDR-COUNTRY-CD"},
+		{&c.AddrZip, 234, 10, "EXP-CUST-ADDR-ZIP"},
+		{&c.PhoneNum1, 244, 15, "EXP-CUST-PHONE-NUM(1)"},
+		{&c.PhoneNum2, 259, 15, "EXP-CUST-PHONE-NUM(2)"},
+		{&c.GovtIssuedID, 283, 20, "EXP-CUST-GOVT-ISSUED-ID"},
+		{&c.DOB, 303, 10, "EXP-CUST-DOB-YYYY-MM-DD"},
+		{&c.EFTAccountID, 313, 10, "EXP-CUST-EFT-ACCOUNT-ID"},
+		{&c.PriCardHolderInd, 323, 1, "EXP-CUST-PRI-CARD-HOLDER-IND"},
+	} {
+		*af.dst, err = cobolfmt.DecodeEBCDICTrimmed(d[af.off : af.off+af.n])
+		if err != nil {
+			return nil, fmt.Errorf("%s: %w", af.label, err)
+		}
+	}
+	c.SSN, err = cobolfmt.DecodeZonedUint(d[274:283])
+	if err != nil {
+		return nil, fmt.Errorf("EXP-CUST-SSN: %w", err)
+	}
+	// PIC 9(03) COMP-3 — unsigned, sign nibble 0xF.
+	c.FICOCreditScore, err = cobolfmt.DecodePacked(d[324:326], 0)
+	if err != nil {
+		return nil, fmt.Errorf("EXP-CUST-FICO-CREDIT-SCORE: %w", err)
+	}
+	return &c, nil
+}
+
+func decodeExportAccount(d []byte) (*ExportAccountData, error) {
+	var a ExportAccountData
+	var err error
+
+	a.AcctID, err = cobolfmt.DecodeZonedUint(d[0:11])
+	if err != nil {
+		return nil, fmt.Errorf("EXP-ACCT-ID: %w", err)
+	}
+	a.AcctActiveStatus, err = cobolfmt.DecodeEBCDICTrimmed(d[11:12])
+	if err != nil {
+		return nil, fmt.Errorf("EXP-ACCT-ACTIVE-STATUS: %w", err)
+	}
+	// PIC S9(10)V99 COMP-3 (12 digits, scale=2, signed).
+	a.AcctCurrBal, err = cobolfmt.DecodePacked(d[12:19], 2)
+	if err != nil {
+		return nil, fmt.Errorf("EXP-ACCT-CURR-BAL: %w", err)
+	}
+	a.AcctCreditLimit, err = cobolfmt.DecodeZoned(d[19:31], 2, true)
+	if err != nil {
+		return nil, fmt.Errorf("EXP-ACCT-CREDIT-LIMIT: %w", err)
+	}
+	// PIC S9(10)V99 COMP-3 (12 digits, scale=2, signed).
+	a.AcctCashCredit, err = cobolfmt.DecodePacked(d[31:38], 2)
+	if err != nil {
+		return nil, fmt.Errorf("EXP-ACCT-CASH-CREDIT-LIMIT: %w", err)
+	}
+	for _, af := range []struct {
+		dst    *string
+		off, n int
+		label  string
+	}{
+		{&a.AcctOpenDate, 38, 10, "EXP-ACCT-OPEN-DATE"},
+		{&a.AcctExpiryDate, 48, 10, "EXP-ACCT-EXPIRAION-DATE"},
+		{&a.AcctReissueDate, 58, 10, "EXP-ACCT-REISSUE-DATE"},
+	} {
+		*af.dst, err = cobolfmt.DecodeEBCDICTrimmed(d[af.off : af.off+af.n])
+		if err != nil {
+			return nil, fmt.Errorf("%s: %w", af.label, err)
+		}
+	}
+	a.AcctCurrCycCredit, err = cobolfmt.DecodeZoned(d[68:80], 2, true)
+	if err != nil {
+		return nil, fmt.Errorf("EXP-ACCT-CURR-CYC-CREDIT: %w", err)
+	}
+	// PIC S9(10)V99 COMP (12 digits, scale=2, signed binary).
+	// The stored integer represents value × 100.
+	rawDebit, err := cobolfmt.DecodeComp(d[80:88], true)
+	if err != nil {
+		return nil, fmt.Errorf("EXP-ACCT-CURR-CYC-DEBIT: %w", err)
+	}
+	a.AcctCurrCycDebit = decimal.NewFromInt(rawDebit).Shift(-2)
+	for _, af := range []struct {
+		dst    *string
+		off, n int
+		label  string
+	}{
+		{&a.AcctAddrZip, 88, 10, "EXP-ACCT-ADDR-ZIP"},
+		{&a.AcctGroupID, 98, 10, "EXP-ACCT-GROUP-ID"},
+	} {
+		*af.dst, err = cobolfmt.DecodeEBCDICTrimmed(d[af.off : af.off+af.n])
+		if err != nil {
+			return nil, fmt.Errorf("%s: %w", af.label, err)
+		}
+	}
+	return &a, nil
+}
+
+func decodeExportTransaction(d []byte) (*ExportTransactionData, error) {
+	var t ExportTransactionData
+	var err error
+
+	for _, af := range []struct {
+		dst    *string
+		off, n int
+		label  string
+	}{
+		{&t.TranID, 0, 16, "EXP-TRAN-ID"},
+		{&t.TranTypeCode, 16, 2, "EXP-TRAN-TYPE-CD"},
+		{&t.TranSource, 22, 10, "EXP-TRAN-SOURCE"},
+		{&t.TranDesc, 32, 100, "EXP-TRAN-DESC"},
+	} {
+		*af.dst, err = cobolfmt.DecodeEBCDICTrimmed(d[af.off : af.off+af.n])
+		if err != nil {
+			return nil, fmt.Errorf("%s: %w", af.label, err)
+		}
+	}
+	t.TranCatCode, err = cobolfmt.DecodeZonedUint(d[18:22])
+	if err != nil {
+		return nil, fmt.Errorf("EXP-TRAN-CAT-CD: %w", err)
+	}
+	// PIC S9(09)V99 COMP-3 (11 digits, scale=2, signed).
+	t.TranAmt, err = cobolfmt.DecodePacked(d[132:138], 2)
+	if err != nil {
+		return nil, fmt.Errorf("EXP-TRAN-AMT: %w", err)
+	}
+	t.TranMerchantID, err = cobolfmt.DecodeComp(d[138:142], false)
+	if err != nil {
+		return nil, fmt.Errorf("EXP-TRAN-MERCHANT-ID: %w", err)
+	}
+	for _, af := range []struct {
+		dst    *string
+		off, n int
+		label  string
+	}{
+		{&t.MerchantName, 142, 50, "EXP-TRAN-MERCHANT-NAME"},
+		{&t.MerchantCity, 192, 50, "EXP-TRAN-MERCHANT-CITY"},
+		{&t.MerchantZip, 242, 10, "EXP-TRAN-MERCHANT-ZIP"},
+		{&t.TranCardNum, 252, 16, "EXP-TRAN-CARD-NUM"},
+		{&t.TranOrigTS, 268, 26, "EXP-TRAN-ORIG-TS"},
+		{&t.TranProcTS, 294, 26, "EXP-TRAN-PROC-TS"},
+	} {
+		*af.dst, err = cobolfmt.DecodeEBCDICTrimmed(d[af.off : af.off+af.n])
+		if err != nil {
+			return nil, fmt.Errorf("%s: %w", af.label, err)
+		}
+	}
+	return &t, nil
+}
+
+func decodeExportCardXref(d []byte) (*ExportCardXrefData, error) {
+	var x ExportCardXrefData
+	var err error
+
+	x.XrefCardNum, err = cobolfmt.DecodeEBCDICTrimmed(d[0:16])
+	if err != nil {
+		return nil, fmt.Errorf("EXP-XREF-CARD-NUM: %w", err)
+	}
+	x.XrefCustID, err = cobolfmt.DecodeZonedUint(d[16:25])
+	if err != nil {
+		return nil, fmt.Errorf("EXP-XREF-CUST-ID: %w", err)
+	}
+	x.XrefAcctID, err = cobolfmt.DecodeComp(d[25:33], false)
+	if err != nil {
+		return nil, fmt.Errorf("EXP-XREF-ACCT-ID: %w", err)
+	}
+	return &x, nil
+}
+
+func decodeExportCard(d []byte) (*ExportCardData, error) {
+	var c ExportCardData
+	var err error
+
+	c.CardNum, err = cobolfmt.DecodeEBCDICTrimmed(d[0:16])
+	if err != nil {
+		return nil, fmt.Errorf("EXP-CARD-NUM: %w", err)
+	}
+	c.CardAcctID, err = cobolfmt.DecodeComp(d[16:24], false)
+	if err != nil {
+		return nil, fmt.Errorf("EXP-CARD-ACCT-ID: %w", err)
+	}
+	c.CardCVVCode, err = cobolfmt.DecodeComp(d[24:26], false)
+	if err != nil {
+		return nil, fmt.Errorf("EXP-CARD-CVV-CD: %w", err)
+	}
+	for _, af := range []struct {
+		dst    *string
+		off, n int
+		label  string
+	}{
+		{&c.CardEmbossed, 26, 50, "EXP-CARD-EMBOSSED-NAME"},
+		{&c.CardExpiryDate, 76, 10, "EXP-CARD-EXPIRAION-DATE"},
+		{&c.CardActive, 86, 1, "EXP-CARD-ACTIVE-STATUS"},
+	} {
+		*af.dst, err = cobolfmt.DecodeEBCDICTrimmed(d[af.off : af.off+af.n])
+		if err != nil {
+			return nil, fmt.Errorf("%s: %w", af.label, err)
+		}
+	}
+	return &c, nil
+}
+
+// Encode serialises an ExportRecord back to its 500-byte representation.
+func (r *ExportRecord) Encode() ([]byte, error) {
+	out := make([]byte, ExportRecordLen)
+
+	// Header fields.
+	ftype, err := cobolfmt.EncodeEBCDIC(cobolfmt.PadRight(r.RecType, 1), 1)
+	if err != nil {
+		return nil, fmt.Errorf("domain: export: EXPORT-REC-TYPE: %w", err)
+	}
+	copy(out[0:1], ftype)
+
+	fts, err := cobolfmt.EncodeEBCDIC(cobolfmt.PadRight(r.Timestamp, 26), 26)
+	if err != nil {
+		return nil, fmt.Errorf("domain: export: EXPORT-TIMESTAMP: %w", err)
+	}
+	copy(out[1:27], fts)
+
+	fseq, err := cobolfmt.EncodeComp(r.SequenceNum, 4)
+	if err != nil {
+		return nil, fmt.Errorf("domain: export: EXPORT-SEQUENCE-NUM: %w", err)
+	}
+	copy(out[27:31], fseq)
+
+	fbranch, err := cobolfmt.EncodeEBCDIC(cobolfmt.PadRight(r.BranchID, 4), 4)
+	if err != nil {
+		return nil, fmt.Errorf("domain: export: EXPORT-BRANCH-ID: %w", err)
+	}
+	copy(out[31:35], fbranch)
+
+	fregion, err := cobolfmt.EncodeEBCDIC(cobolfmt.PadRight(r.RegionCode, 5), 5)
+	if err != nil {
+		return nil, fmt.Errorf("domain: export: EXPORT-REGION-CODE: %w", err)
+	}
+	copy(out[35:40], fregion)
+
+	// Data section.
+	var dataSec []byte
+	switch r.RecType {
+	case "C":
+		if r.Customer == nil {
+			return nil, fmt.Errorf("domain: export: Customer data is nil for type C")
+		}
+		dataSec, err = r.Customer.encode()
+	case "A":
+		if r.Account == nil {
+			return nil, fmt.Errorf("domain: export: Account data is nil for type A")
+		}
+		dataSec, err = r.Account.encode()
+	case "T":
+		if r.Transaction == nil {
+			return nil, fmt.Errorf("domain: export: Transaction data is nil for type T")
+		}
+		dataSec, err = r.Transaction.encode()
+	case "X":
+		if r.CardXref == nil {
+			return nil, fmt.Errorf("domain: export: CardXref data is nil for type X")
+		}
+		dataSec, err = r.CardXref.encode()
+	case "D":
+		if r.Card == nil {
+			return nil, fmt.Errorf("domain: export: Card data is nil for type D")
+		}
+		dataSec, err = r.Card.encode()
+	default:
+		return nil, fmt.Errorf("domain: export: unknown record type %q", r.RecType)
+	}
+	if err != nil {
+		return nil, fmt.Errorf("domain: export: type %q: %w", r.RecType, err)
+	}
+	copy(out[exportHeaderLen:], dataSec)
+	return out, nil
+}
+
+func (c *ExportCustomerData) encode() ([]byte, error) {
+	out := make([]byte, exportDataLen)
+
+	fid, err := cobolfmt.EncodeComp(c.CustID, 4)
+	if err != nil {
+		return nil, fmt.Errorf("EXP-CUST-ID: %w", err)
+	}
+	copy(out[0:4], fid)
+
+	for _, af := range []struct {
+		val    string
+		off, n int
+		label  string
+	}{
+		{c.FirstName, 4, 25, "EXP-CUST-FIRST-NAME"},
+		{c.MiddleName, 29, 25, "EXP-CUST-MIDDLE-NAME"},
+		{c.LastName, 54, 25, "EXP-CUST-LAST-NAME"},
+		{c.AddrLine1, 79, 50, "EXP-CUST-ADDR-LINE(1)"},
+		{c.AddrLine2, 129, 50, "EXP-CUST-ADDR-LINE(2)"},
+		{c.AddrLine3, 179, 50, "EXP-CUST-ADDR-LINE(3)"},
+		{c.AddrStateCode, 229, 2, "EXP-CUST-ADDR-STATE-CD"},
+		{c.AddrCountryCode, 231, 3, "EXP-CUST-ADDR-COUNTRY-CD"},
+		{c.AddrZip, 234, 10, "EXP-CUST-ADDR-ZIP"},
+		{c.PhoneNum1, 244, 15, "EXP-CUST-PHONE-NUM(1)"},
+		{c.PhoneNum2, 259, 15, "EXP-CUST-PHONE-NUM(2)"},
+		{c.GovtIssuedID, 283, 20, "EXP-CUST-GOVT-ISSUED-ID"},
+		{c.DOB, 303, 10, "EXP-CUST-DOB-YYYY-MM-DD"},
+		{c.EFTAccountID, 313, 10, "EXP-CUST-EFT-ACCOUNT-ID"},
+		{c.PriCardHolderInd, 323, 1, "EXP-CUST-PRI-CARD-HOLDER-IND"},
+	} {
+		fb, ferr := cobolfmt.EncodeEBCDIC(cobolfmt.PadRight(af.val, af.n), af.n)
+		if ferr != nil {
+			return nil, fmt.Errorf("%s: %w", af.label, ferr)
+		}
+		copy(out[af.off:af.off+af.n], fb)
+	}
+
+	fssn, err := cobolfmt.EncodeZonedUint(c.SSN, 9)
+	if err != nil {
+		return nil, fmt.Errorf("EXP-CUST-SSN: %w", err)
+	}
+	copy(out[274:283], fssn)
+
+	// PIC 9(03) COMP-3 — unsigned, emit 0xF sign nibble.
+	ffico, err := cobolfmt.EncodePacked(c.FICOCreditScore, 3, 0, true)
+	if err != nil {
+		return nil, fmt.Errorf("EXP-CUST-FICO-CREDIT-SCORE: %w", err)
+	}
+	copy(out[324:326], ffico)
+
+	copy(out[326:460], cobolfmt.EBCDICSpacePad(134))
+	return out, nil
+}
+
+func (a *ExportAccountData) encode() ([]byte, error) {
+	out := make([]byte, exportDataLen)
+
+	fid, err := cobolfmt.EncodeZonedUint(a.AcctID, 11)
+	if err != nil {
+		return nil, fmt.Errorf("EXP-ACCT-ID: %w", err)
+	}
+	copy(out[0:11], fid)
+
+	fstatus, err := cobolfmt.EncodeEBCDIC(cobolfmt.PadRight(a.AcctActiveStatus, 1), 1)
+	if err != nil {
+		return nil, fmt.Errorf("EXP-ACCT-ACTIVE-STATUS: %w", err)
+	}
+	copy(out[11:12], fstatus)
+
+	// PIC S9(10)V99 COMP-3 (12 digits, scale=2, signed).
+	fbal, err := cobolfmt.EncodePacked(a.AcctCurrBal, 12, 2, false)
+	if err != nil {
+		return nil, fmt.Errorf("EXP-ACCT-CURR-BAL: %w", err)
+	}
+	copy(out[12:19], fbal)
+
+	fcredit, err := cobolfmt.EncodeZoned(a.AcctCreditLimit, 12, 2, true)
+	if err != nil {
+		return nil, fmt.Errorf("EXP-ACCT-CREDIT-LIMIT: %w", err)
+	}
+	copy(out[19:31], fcredit)
+
+	// PIC S9(10)V99 COMP-3 (12 digits, scale=2, signed).
+	fcash, err := cobolfmt.EncodePacked(a.AcctCashCredit, 12, 2, false)
+	if err != nil {
+		return nil, fmt.Errorf("EXP-ACCT-CASH-CREDIT-LIMIT: %w", err)
+	}
+	copy(out[31:38], fcash)
+
+	for _, af := range []struct {
+		val    string
+		off, n int
+		label  string
+	}{
+		{a.AcctOpenDate, 38, 10, "EXP-ACCT-OPEN-DATE"},
+		{a.AcctExpiryDate, 48, 10, "EXP-ACCT-EXPIRAION-DATE"},
+		{a.AcctReissueDate, 58, 10, "EXP-ACCT-REISSUE-DATE"},
+	} {
+		fb, ferr := cobolfmt.EncodeEBCDIC(cobolfmt.PadRight(af.val, af.n), af.n)
+		if ferr != nil {
+			return nil, fmt.Errorf("%s: %w", af.label, ferr)
+		}
+		copy(out[af.off:af.off+af.n], fb)
+	}
+
+	fccredit, err := cobolfmt.EncodeZoned(a.AcctCurrCycCredit, 12, 2, true)
+	if err != nil {
+		return nil, fmt.Errorf("EXP-ACCT-CURR-CYC-CREDIT: %w", err)
+	}
+	copy(out[68:80], fccredit)
+
+	// PIC S9(10)V99 COMP — stored as binary integer (value × 100).
+	rawDebit := a.AcctCurrCycDebit.Shift(2).IntPart()
+	fdebit, err := cobolfmt.EncodeComp(rawDebit, 8)
+	if err != nil {
+		return nil, fmt.Errorf("EXP-ACCT-CURR-CYC-DEBIT: %w", err)
+	}
+	copy(out[80:88], fdebit)
+
+	for _, af := range []struct {
+		val    string
+		off, n int
+		label  string
+	}{
+		{a.AcctAddrZip, 88, 10, "EXP-ACCT-ADDR-ZIP"},
+		{a.AcctGroupID, 98, 10, "EXP-ACCT-GROUP-ID"},
+	} {
+		fb, ferr := cobolfmt.EncodeEBCDIC(cobolfmt.PadRight(af.val, af.n), af.n)
+		if ferr != nil {
+			return nil, fmt.Errorf("%s: %w", af.label, ferr)
+		}
+		copy(out[af.off:af.off+af.n], fb)
+	}
+
+	copy(out[108:460], cobolfmt.EBCDICSpacePad(352))
+	return out, nil
+}
+
+func (t *ExportTransactionData) encode() ([]byte, error) {
+	out := make([]byte, exportDataLen)
+
+	for _, af := range []struct {
+		val    string
+		off, n int
+		label  string
+	}{
+		{t.TranID, 0, 16, "EXP-TRAN-ID"},
+		{t.TranTypeCode, 16, 2, "EXP-TRAN-TYPE-CD"},
+		{t.TranSource, 22, 10, "EXP-TRAN-SOURCE"},
+		{t.TranDesc, 32, 100, "EXP-TRAN-DESC"},
+		{t.MerchantName, 142, 50, "EXP-TRAN-MERCHANT-NAME"},
+		{t.MerchantCity, 192, 50, "EXP-TRAN-MERCHANT-CITY"},
+		{t.MerchantZip, 242, 10, "EXP-TRAN-MERCHANT-ZIP"},
+		{t.TranCardNum, 252, 16, "EXP-TRAN-CARD-NUM"},
+		{t.TranOrigTS, 268, 26, "EXP-TRAN-ORIG-TS"},
+		{t.TranProcTS, 294, 26, "EXP-TRAN-PROC-TS"},
+	} {
+		fb, ferr := cobolfmt.EncodeEBCDIC(cobolfmt.PadRight(af.val, af.n), af.n)
+		if ferr != nil {
+			return nil, fmt.Errorf("%s: %w", af.label, ferr)
+		}
+		copy(out[af.off:af.off+af.n], fb)
+	}
+
+	fcat, err := cobolfmt.EncodeZonedUint(t.TranCatCode, 4)
+	if err != nil {
+		return nil, fmt.Errorf("EXP-TRAN-CAT-CD: %w", err)
+	}
+	copy(out[18:22], fcat)
+
+	// PIC S9(09)V99 COMP-3 (11 digits, scale=2, signed).
+	famt, err := cobolfmt.EncodePacked(t.TranAmt, 11, 2, false)
+	if err != nil {
+		return nil, fmt.Errorf("EXP-TRAN-AMT: %w", err)
+	}
+	copy(out[132:138], famt)
+
+	fmid, err := cobolfmt.EncodeComp(t.TranMerchantID, 4)
+	if err != nil {
+		return nil, fmt.Errorf("EXP-TRAN-MERCHANT-ID: %w", err)
+	}
+	copy(out[138:142], fmid)
+
+	copy(out[320:460], cobolfmt.EBCDICSpacePad(140))
+	return out, nil
+}
+
+func (x *ExportCardXrefData) encode() ([]byte, error) {
+	out := make([]byte, exportDataLen)
+
+	fnum, err := cobolfmt.EncodeEBCDIC(cobolfmt.PadRight(x.XrefCardNum, 16), 16)
+	if err != nil {
+		return nil, fmt.Errorf("EXP-XREF-CARD-NUM: %w", err)
+	}
+	copy(out[0:16], fnum)
+
+	fcust, err := cobolfmt.EncodeZonedUint(x.XrefCustID, 9)
+	if err != nil {
+		return nil, fmt.Errorf("EXP-XREF-CUST-ID: %w", err)
+	}
+	copy(out[16:25], fcust)
+
+	facct, err := cobolfmt.EncodeComp(x.XrefAcctID, 8)
+	if err != nil {
+		return nil, fmt.Errorf("EXP-XREF-ACCT-ID: %w", err)
+	}
+	copy(out[25:33], facct)
+
+	copy(out[33:460], cobolfmt.EBCDICSpacePad(427))
+	return out, nil
+}
+
+func (c *ExportCardData) encode() ([]byte, error) {
+	out := make([]byte, exportDataLen)
+
+	fnum, err := cobolfmt.EncodeEBCDIC(cobolfmt.PadRight(c.CardNum, 16), 16)
+	if err != nil {
+		return nil, fmt.Errorf("EXP-CARD-NUM: %w", err)
+	}
+	copy(out[0:16], fnum)
+
+	facct, err := cobolfmt.EncodeComp(c.CardAcctID, 8)
+	if err != nil {
+		return nil, fmt.Errorf("EXP-CARD-ACCT-ID: %w", err)
+	}
+	copy(out[16:24], facct)
+
+	fcvv, err := cobolfmt.EncodeComp(c.CardCVVCode, 2)
+	if err != nil {
+		return nil, fmt.Errorf("EXP-CARD-CVV-CD: %w", err)
+	}
+	copy(out[24:26], fcvv)
+
+	for _, af := range []struct {
+		val    string
+		off, n int
+		label  string
+	}{
+		{c.CardEmbossed, 26, 50, "EXP-CARD-EMBOSSED-NAME"},
+		{c.CardExpiryDate, 76, 10, "EXP-CARD-EXPIRAION-DATE"},
+		{c.CardActive, 86, 1, "EXP-CARD-ACTIVE-STATUS"},
+	} {
+		fb, ferr := cobolfmt.EncodeEBCDIC(cobolfmt.PadRight(af.val, af.n), af.n)
+		if ferr != nil {
+			return nil, fmt.Errorf("%s: %w", af.label, ferr)
+		}
+		copy(out[af.off:af.off+af.n], fb)
+	}
+
+	copy(out[87:460], cobolfmt.EBCDICSpacePad(373))
+	return out, nil
+}
+
+// DecodeExportRecords reads all ExportRecords from a flat 500-byte-per-record file.
+func DecodeExportRecords(data []byte) ([]*ExportRecord, error) {
+	if len(data)%ExportRecordLen != 0 {
+		return nil, fmt.Errorf("domain: export: data length %d is not a multiple of %d", len(data), ExportRecordLen)
+	}
+	count := len(data) / ExportRecordLen
+	records := make([]*ExportRecord, 0, count)
+	for i := 0; i < count; i++ {
+		rec, err := DecodeExportRecord(data[i*ExportRecordLen : (i+1)*ExportRecordLen])
+		if err != nil {
+			return nil, fmt.Errorf("domain: export: record %d: %w", i, err)
+		}
+		records = append(records, rec)
+	}
+	return records, nil
+}

--- a/internal/domain/roundtrip_test.go
+++ b/internal/domain/roundtrip_test.go
@@ -323,6 +323,53 @@ func TestUserSecRoundTrip(t *testing.T) {
 	t.Logf("tested %d user-sec records byte-for-byte", count)
 }
 
+// TestExportRoundTrip decodes every record from the multi-record CVEXPORT
+// fixture and re-encodes it, verifying byte-identical output.
+//
+// This test exercises the COMP and COMP-3 fields in CVEXPORT.cpy:
+//   - EXP-CUST-FICO-CREDIT-SCORE PIC 9(03) COMP-3 (unsigned, 0xF sign nibble)
+//   - EXP-ACCT-CURR-BAL / EXP-ACCT-CASH-CREDIT-LIMIT PIC S9(10)V99 COMP-3
+//   - EXP-TRAN-AMT PIC S9(09)V99 COMP-3
+//   - Various COMP binary fields
+//
+// The fixture is required; the test fails (not skips) if it is absent so
+// that CI cannot pass vacuously on a checkout without fixtures.
+func TestExportRoundTrip(t *testing.T) {
+	dir := fixtureDir(t)
+	path := filepath.Join(dir, "AWS.M2.CARDDEMO.EXPORT.DATA.PS")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("fixture %s not found: %v — fixture is required for this test", path, err)
+	}
+
+	if len(data)%domain.ExportRecordLen != 0 {
+		t.Fatalf("fixture length %d not a multiple of %d", len(data), domain.ExportRecordLen)
+	}
+
+	count := len(data) / domain.ExportRecordLen
+	for i := 0; i < count; i++ {
+		raw := data[i*domain.ExportRecordLen : (i+1)*domain.ExportRecordLen]
+
+		rec, err := domain.DecodeExportRecord(raw)
+		if err != nil {
+			t.Errorf("record %d: DecodeExportRecord: %v", i, err)
+			continue
+		}
+
+		encoded, err := rec.Encode()
+		if err != nil {
+			t.Errorf("record %d: Encode: %v", i, err)
+			continue
+		}
+
+		if !bytes.Equal(raw, encoded) {
+			t.Errorf("record %d (type %q): round-trip mismatch\n  orig:    %X\n  encoded: %X",
+				i, rec.RecType, raw[:min(64, len(raw))], encoded[:min(64, len(encoded))])
+		}
+	}
+	t.Logf("tested %d export records byte-for-byte", count)
+}
+
 func min(a, b int) int {
 	if a < b {
 		return a

--- a/internal/domain/roundtrip_test.go
+++ b/internal/domain/roundtrip_test.go
@@ -1,0 +1,331 @@
+package domain_test
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/aws-samples/aws-mainframe-modernization-carddemo/internal/domain"
+)
+
+// fixtureDir returns the path to the EBCDIC fixture directory relative to the
+// repo root.  Tests are run from internal/domain/ so we walk up two levels.
+func fixtureDir(t *testing.T) string {
+	t.Helper()
+	_, thisFile, _, _ := runtime.Caller(0)
+	// thisFile = …/internal/domain/roundtrip_test.go
+	repoRoot := filepath.Join(filepath.Dir(thisFile), "..", "..")
+	dir := filepath.Join(repoRoot, "app", "data", "EBCDIC")
+	if _, err := os.Stat(dir); os.IsNotExist(err) {
+		t.Skipf("EBCDIC fixture directory not found at %s; skipping round-trip test", dir)
+	}
+	return dir
+}
+
+func readFixture(t *testing.T, dir, name string) []byte {
+	t.Helper()
+	path := filepath.Join(dir, name)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Skipf("fixture %s not found: %v", name, err)
+	}
+	return data
+}
+
+// TestAccountRoundTrip decodes every account record from the EBCDIC fixture
+// file and re-encodes it, checking for byte-identical output.
+func TestAccountRoundTrip(t *testing.T) {
+	dir := fixtureDir(t)
+	data := readFixture(t, dir, "AWS.M2.CARDDEMO.ACCTDATA.PS")
+
+	if len(data)%domain.AccountRecordLen != 0 {
+		t.Fatalf("fixture length %d not a multiple of %d", len(data), domain.AccountRecordLen)
+	}
+
+	count := len(data) / domain.AccountRecordLen
+	for i := 0; i < count; i++ {
+		raw := data[i*domain.AccountRecordLen : (i+1)*domain.AccountRecordLen]
+
+		rec, err := domain.DecodeAccountRecord(raw)
+		if err != nil {
+			t.Errorf("record %d: DecodeAccountRecord: %v", i, err)
+			continue
+		}
+
+		encoded, err := rec.Encode()
+		if err != nil {
+			t.Errorf("record %d: Encode: %v", i, err)
+			continue
+		}
+
+		if !bytes.Equal(raw, encoded) {
+			t.Errorf("record %d: round-trip mismatch\n  orig:    %X\n  encoded: %X", i, raw[:min(32, len(raw))], encoded[:min(32, len(encoded))])
+		}
+	}
+	t.Logf("tested %d account records byte-for-byte", count)
+}
+
+// TestCustomerRoundTrip decodes every customer record and re-encodes it.
+func TestCustomerRoundTrip(t *testing.T) {
+	dir := fixtureDir(t)
+	data := readFixture(t, dir, "AWS.M2.CARDDEMO.CUSTDATA.PS")
+
+	if len(data)%domain.CustomerRecordLen != 0 {
+		t.Fatalf("fixture length %d not a multiple of %d", len(data), domain.CustomerRecordLen)
+	}
+
+	count := len(data) / domain.CustomerRecordLen
+	for i := 0; i < count; i++ {
+		raw := data[i*domain.CustomerRecordLen : (i+1)*domain.CustomerRecordLen]
+
+		rec, err := domain.DecodeCustomerRecord(raw)
+		if err != nil {
+			t.Errorf("record %d: DecodeCustomerRecord: %v", i, err)
+			continue
+		}
+
+		encoded, err := rec.Encode()
+		if err != nil {
+			t.Errorf("record %d: Encode: %v", i, err)
+			continue
+		}
+
+		if !bytes.Equal(raw, encoded) {
+			t.Errorf("record %d: round-trip mismatch\n  orig:    %X\n  encoded: %X", i, raw[:min(32, len(raw))], encoded[:min(32, len(encoded))])
+		}
+	}
+	t.Logf("tested %d customer records byte-for-byte", count)
+}
+
+// TestCardRoundTrip decodes every card record and re-encodes it.
+func TestCardRoundTrip(t *testing.T) {
+	dir := fixtureDir(t)
+	data := readFixture(t, dir, "AWS.M2.CARDDEMO.CARDDATA.PS")
+
+	if len(data)%domain.CardRecordLen != 0 {
+		t.Fatalf("fixture length %d not a multiple of %d", len(data), domain.CardRecordLen)
+	}
+
+	count := len(data) / domain.CardRecordLen
+	for i := 0; i < count; i++ {
+		raw := data[i*domain.CardRecordLen : (i+1)*domain.CardRecordLen]
+
+		rec, err := domain.DecodeCardRecord(raw)
+		if err != nil {
+			t.Errorf("record %d: DecodeCardRecord: %v", i, err)
+			continue
+		}
+
+		encoded, err := rec.Encode()
+		if err != nil {
+			t.Errorf("record %d: Encode: %v", i, err)
+			continue
+		}
+
+		if !bytes.Equal(raw, encoded) {
+			t.Errorf("record %d: round-trip mismatch\n  orig:    %X\n  encoded: %X", i, raw[:min(32, len(raw))], encoded[:min(32, len(encoded))])
+		}
+	}
+	t.Logf("tested %d card records byte-for-byte", count)
+}
+
+// TestCardXrefRoundTrip decodes every card cross-reference record and re-encodes it.
+func TestCardXrefRoundTrip(t *testing.T) {
+	dir := fixtureDir(t)
+	data := readFixture(t, dir, "AWS.M2.CARDDEMO.CARDXREF.PS")
+
+	if len(data)%domain.CardXrefRecordLen != 0 {
+		t.Fatalf("fixture length %d not a multiple of %d", len(data), domain.CardXrefRecordLen)
+	}
+
+	count := len(data) / domain.CardXrefRecordLen
+	for i := 0; i < count; i++ {
+		raw := data[i*domain.CardXrefRecordLen : (i+1)*domain.CardXrefRecordLen]
+
+		rec, err := domain.DecodeCardXrefRecord(raw)
+		if err != nil {
+			t.Errorf("record %d: DecodeCardXrefRecord: %v", i, err)
+			continue
+		}
+
+		encoded, err := rec.Encode()
+		if err != nil {
+			t.Errorf("record %d: Encode: %v", i, err)
+			continue
+		}
+
+		if !bytes.Equal(raw, encoded) {
+			t.Errorf("record %d: round-trip mismatch\n  orig:    %X\n  encoded: %X", i, raw[:min(32, len(raw))], encoded[:min(32, len(encoded))])
+		}
+	}
+	t.Logf("tested %d card-xref records byte-for-byte", count)
+}
+
+// TestTranTypeRoundTrip decodes every transaction-type record and re-encodes it.
+func TestTranTypeRoundTrip(t *testing.T) {
+	dir := fixtureDir(t)
+	data := readFixture(t, dir, "AWS.M2.CARDDEMO.TRANTYPE.PS")
+
+	if len(data)%domain.TranTypeRecordLen != 0 {
+		t.Fatalf("fixture length %d not a multiple of %d", len(data), domain.TranTypeRecordLen)
+	}
+
+	count := len(data) / domain.TranTypeRecordLen
+	for i := 0; i < count; i++ {
+		raw := data[i*domain.TranTypeRecordLen : (i+1)*domain.TranTypeRecordLen]
+
+		rec, err := domain.DecodeTranTypeRecord(raw)
+		if err != nil {
+			t.Errorf("record %d: DecodeTranTypeRecord: %v", i, err)
+			continue
+		}
+
+		encoded, err := rec.Encode()
+		if err != nil {
+			t.Errorf("record %d: Encode: %v", i, err)
+			continue
+		}
+
+		if !bytes.Equal(raw, encoded) {
+			t.Errorf("record %d: round-trip mismatch\n  orig:    %X\n  encoded: %X", i, raw, encoded)
+		}
+	}
+	t.Logf("tested %d tran-type records byte-for-byte", count)
+}
+
+// TestTranCatRoundTrip decodes every transaction-category record and re-encodes it.
+func TestTranCatRoundTrip(t *testing.T) {
+	dir := fixtureDir(t)
+	data := readFixture(t, dir, "AWS.M2.CARDDEMO.TRANCATG.PS")
+
+	if len(data)%domain.TranCatRecordLen != 0 {
+		t.Fatalf("fixture length %d not a multiple of %d", len(data), domain.TranCatRecordLen)
+	}
+
+	count := len(data) / domain.TranCatRecordLen
+	for i := 0; i < count; i++ {
+		raw := data[i*domain.TranCatRecordLen : (i+1)*domain.TranCatRecordLen]
+
+		rec, err := domain.DecodeTranCatRecord(raw)
+		if err != nil {
+			t.Errorf("record %d: DecodeTranCatRecord: %v", i, err)
+			continue
+		}
+
+		encoded, err := rec.Encode()
+		if err != nil {
+			t.Errorf("record %d: Encode: %v", i, err)
+			continue
+		}
+
+		if !bytes.Equal(raw, encoded) {
+			t.Errorf("record %d: round-trip mismatch\n  orig:    %X\n  encoded: %X", i, raw, encoded)
+		}
+	}
+	t.Logf("tested %d tran-cat records byte-for-byte", count)
+}
+
+// TestDiscGroupRoundTrip decodes every disclosure-group record and re-encodes it.
+func TestDiscGroupRoundTrip(t *testing.T) {
+	dir := fixtureDir(t)
+	data := readFixture(t, dir, "AWS.M2.CARDDEMO.DISCGRP.PS")
+
+	if len(data)%domain.DiscGroupRecordLen != 0 {
+		t.Fatalf("fixture length %d not a multiple of %d", len(data), domain.DiscGroupRecordLen)
+	}
+
+	count := len(data) / domain.DiscGroupRecordLen
+	for i := 0; i < count; i++ {
+		raw := data[i*domain.DiscGroupRecordLen : (i+1)*domain.DiscGroupRecordLen]
+
+		rec, err := domain.DecodeDiscGroupRecord(raw)
+		if err != nil {
+			t.Errorf("record %d: DecodeDiscGroupRecord: %v", i, err)
+			continue
+		}
+
+		encoded, err := rec.Encode()
+		if err != nil {
+			t.Errorf("record %d: Encode: %v", i, err)
+			continue
+		}
+
+		if !bytes.Equal(raw, encoded) {
+			t.Errorf("record %d: round-trip mismatch\n  orig:    %X\n  encoded: %X", i, raw, encoded)
+		}
+	}
+	t.Logf("tested %d disc-group records byte-for-byte", count)
+}
+
+// TestTranCatBalRoundTrip decodes every transaction-category-balance record and re-encodes it.
+func TestTranCatBalRoundTrip(t *testing.T) {
+	dir := fixtureDir(t)
+	data := readFixture(t, dir, "AWS.M2.CARDDEMO.TCATBALF.PS")
+
+	if len(data)%domain.TranCatBalRecordLen != 0 {
+		t.Fatalf("fixture length %d not a multiple of %d", len(data), domain.TranCatBalRecordLen)
+	}
+
+	count := len(data) / domain.TranCatBalRecordLen
+	for i := 0; i < count; i++ {
+		raw := data[i*domain.TranCatBalRecordLen : (i+1)*domain.TranCatBalRecordLen]
+
+		rec, err := domain.DecodeTranCatBalRecord(raw)
+		if err != nil {
+			t.Errorf("record %d: DecodeTranCatBalRecord: %v", i, err)
+			continue
+		}
+
+		encoded, err := rec.Encode()
+		if err != nil {
+			t.Errorf("record %d: Encode: %v", i, err)
+			continue
+		}
+
+		if !bytes.Equal(raw, encoded) {
+			t.Errorf("record %d: round-trip mismatch\n  orig:    %X\n  encoded: %X", i, raw, encoded)
+		}
+	}
+	t.Logf("tested %d tran-cat-bal records byte-for-byte", count)
+}
+
+// TestUserSecRoundTrip decodes every user-security record and re-encodes it.
+func TestUserSecRoundTrip(t *testing.T) {
+	dir := fixtureDir(t)
+	data := readFixture(t, dir, "AWS.M2.CARDDEMO.USRSEC.PS")
+
+	if len(data)%domain.UserSecRecordLen != 0 {
+		t.Fatalf("fixture length %d not a multiple of %d", len(data), domain.UserSecRecordLen)
+	}
+
+	count := len(data) / domain.UserSecRecordLen
+	for i := 0; i < count; i++ {
+		raw := data[i*domain.UserSecRecordLen : (i+1)*domain.UserSecRecordLen]
+
+		rec, err := domain.DecodeUserSecRecord(raw)
+		if err != nil {
+			t.Errorf("record %d: DecodeUserSecRecord: %v", i, err)
+			continue
+		}
+
+		encoded, err := rec.Encode()
+		if err != nil {
+			t.Errorf("record %d: Encode: %v", i, err)
+			continue
+		}
+
+		if !bytes.Equal(raw, encoded) {
+			t.Errorf("record %d: round-trip mismatch\n  orig:    %X\n  encoded: %X", i, raw, encoded)
+		}
+	}
+	t.Logf("tested %d user-sec records byte-for-byte", count)
+}
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}

--- a/internal/domain/transaction.go
+++ b/internal/domain/transaction.go
@@ -1,0 +1,315 @@
+package domain
+
+import (
+	"fmt"
+
+	"github.com/aws-samples/aws-mainframe-modernization-carddemo/internal/cobolfmt"
+	"github.com/shopspring/decimal"
+)
+
+// TransactionRecord is the Go port of TRAN-RECORD (CVTRA05Y.cpy, 350 bytes).
+//
+// COBOL layout:
+//
+//	05 TRAN-ID             PIC X(16)       offset   0 len  16
+//	05 TRAN-TYPE-CD        PIC X(02)       offset  16 len   2
+//	05 TRAN-CAT-CD         PIC 9(04)       offset  18 len   4
+//	05 TRAN-SOURCE         PIC X(10)       offset  22 len  10
+//	05 TRAN-DESC           PIC X(100)      offset  32 len 100
+//	05 TRAN-AMT            PIC S9(09)V99   offset 132 len  11
+//	05 TRAN-MERCHANT-ID    PIC 9(09)       offset 143 len   9
+//	05 TRAN-MERCHANT-NAME  PIC X(50)       offset 152 len  50
+//	05 TRAN-MERCHANT-CITY  PIC X(50)       offset 202 len  50
+//	05 TRAN-MERCHANT-ZIP   PIC X(10)       offset 252 len  10
+//	05 TRAN-CARD-NUM       PIC X(16)       offset 262 len  16
+//	05 TRAN-ORIG-TS        PIC X(26)       offset 278 len  26
+//	05 TRAN-PROC-TS        PIC X(26)       offset 304 len  26
+//	05 FILLER              PIC X(20)       offset 330 len  20
+type TransactionRecord struct {
+	TranID           string          `cobol:"TRAN-ID,0,16,alpha"`
+	TranTypeCode     string          `cobol:"TRAN-TYPE-CD,16,2,alpha"`
+	TranCatCode      int64           `cobol:"TRAN-CAT-CD,18,4,zoned_uint"`
+	TranSource       string          `cobol:"TRAN-SOURCE,22,10,alpha"`
+	TranDesc         string          `cobol:"TRAN-DESC,32,100,alpha"`
+	TranAmt          decimal.Decimal `cobol:"TRAN-AMT,132,11,zoned_s2"`
+	TranMerchantID   int64           `cobol:"TRAN-MERCHANT-ID,143,9,zoned_uint"`
+	TranMerchantName string          `cobol:"TRAN-MERCHANT-NAME,152,50,alpha"`
+	TranMerchantCity string          `cobol:"TRAN-MERCHANT-CITY,202,50,alpha"`
+	TranMerchantZip  string          `cobol:"TRAN-MERCHANT-ZIP,252,10,alpha"`
+	TranCardNum      string          `cobol:"TRAN-CARD-NUM,262,16,alpha"`
+	TranOrigTS       string          `cobol:"TRAN-ORIG-TS,278,26,alpha"`
+	TranProcTS       string          `cobol:"TRAN-PROC-TS,304,26,alpha"`
+}
+
+// TransactionRecordLen is the fixed length of a TRAN-RECORD in bytes.
+const TransactionRecordLen = 350
+
+// DecodeTransactionRecord decodes one 350-byte EBCDIC record into a TransactionRecord.
+func DecodeTransactionRecord(b []byte) (*TransactionRecord, error) {
+	if len(b) < TransactionRecordLen {
+		return nil, fmt.Errorf("domain: transaction: record too short: got %d, want %d", len(b), TransactionRecordLen)
+	}
+	b = b[:TransactionRecordLen]
+
+	var r TransactionRecord
+	var err error
+
+	alphaFields := []struct {
+		dst    *string
+		offset int
+		length int
+		label  string
+	}{
+		{&r.TranID, 0, 16, "TRAN-ID"},
+		{&r.TranTypeCode, 16, 2, "TRAN-TYPE-CD"},
+		{&r.TranSource, 22, 10, "TRAN-SOURCE"},
+		{&r.TranDesc, 32, 100, "TRAN-DESC"},
+		{&r.TranMerchantName, 152, 50, "TRAN-MERCHANT-NAME"},
+		{&r.TranMerchantCity, 202, 50, "TRAN-MERCHANT-CITY"},
+		{&r.TranMerchantZip, 252, 10, "TRAN-MERCHANT-ZIP"},
+		{&r.TranCardNum, 262, 16, "TRAN-CARD-NUM"},
+		{&r.TranOrigTS, 278, 26, "TRAN-ORIG-TS"},
+		{&r.TranProcTS, 304, 26, "TRAN-PROC-TS"},
+	}
+	for _, af := range alphaFields {
+		*af.dst, err = cobolfmt.DecodeEBCDICTrimmed(b[af.offset : af.offset+af.length])
+		if err != nil {
+			return nil, fmt.Errorf("domain: transaction: %s: %w", af.label, err)
+		}
+	}
+
+	if r.TranCatCode, err = cobolfmt.DecodeZonedUint(b[18:22]); err != nil {
+		return nil, fmt.Errorf("domain: transaction: TRAN-CAT-CD: %w", err)
+	}
+	if r.TranAmt, err = cobolfmt.DecodeZoned(b[132:143], 2, true); err != nil {
+		return nil, fmt.Errorf("domain: transaction: TRAN-AMT: %w", err)
+	}
+	if r.TranMerchantID, err = cobolfmt.DecodeZonedUint(b[143:152]); err != nil {
+		return nil, fmt.Errorf("domain: transaction: TRAN-MERCHANT-ID: %w", err)
+	}
+
+	return &r, nil
+}
+
+// Encode serialises a TransactionRecord back to its 350-byte EBCDIC representation.
+func (r *TransactionRecord) Encode() ([]byte, error) {
+	out := make([]byte, TransactionRecordLen)
+
+	alphaFields := []struct {
+		val    string
+		offset int
+		length int
+		label  string
+	}{
+		{r.TranID, 0, 16, "TRAN-ID"},
+		{r.TranTypeCode, 16, 2, "TRAN-TYPE-CD"},
+		{r.TranSource, 22, 10, "TRAN-SOURCE"},
+		{r.TranDesc, 32, 100, "TRAN-DESC"},
+		{r.TranMerchantName, 152, 50, "TRAN-MERCHANT-NAME"},
+		{r.TranMerchantCity, 202, 50, "TRAN-MERCHANT-CITY"},
+		{r.TranMerchantZip, 252, 10, "TRAN-MERCHANT-ZIP"},
+		{r.TranCardNum, 262, 16, "TRAN-CARD-NUM"},
+		{r.TranOrigTS, 278, 26, "TRAN-ORIG-TS"},
+		{r.TranProcTS, 304, 26, "TRAN-PROC-TS"},
+	}
+	for _, af := range alphaFields {
+		fb, ferr := cobolfmt.EncodeEBCDIC(cobolfmt.PadRight(af.val, af.length), af.length)
+		if ferr != nil {
+			return nil, fmt.Errorf("domain: transaction: %s: %w", af.label, ferr)
+		}
+		copy(out[af.offset:af.offset+af.length], fb)
+	}
+
+	fcat, err := cobolfmt.EncodeZonedUint(r.TranCatCode, 4)
+	if err != nil {
+		return nil, fmt.Errorf("domain: transaction: TRAN-CAT-CD: %w", err)
+	}
+	copy(out[18:22], fcat)
+
+	famt, err := cobolfmt.EncodeZoned(r.TranAmt, 11, 2, true)
+	if err != nil {
+		return nil, fmt.Errorf("domain: transaction: TRAN-AMT: %w", err)
+	}
+	copy(out[132:143], famt)
+
+	fmid, err := cobolfmt.EncodeZonedUint(r.TranMerchantID, 9)
+	if err != nil {
+		return nil, fmt.Errorf("domain: transaction: TRAN-MERCHANT-ID: %w", err)
+	}
+	copy(out[143:152], fmid)
+
+	copy(out[330:350], cobolfmt.EBCDICSpacePad(20))
+	return out, nil
+}
+
+// DailyTransactionRecord is the Go port of DALYTRAN-RECORD (CVTRA06Y.cpy, 350 bytes).
+// It has the same layout as TransactionRecord with DALYTRAN- prefixed field names.
+type DailyTransactionRecord struct {
+	DalytranID           string          `cobol:"DALYTRAN-ID,0,16,alpha"`
+	DalytranTypeCode     string          `cobol:"DALYTRAN-TYPE-CD,16,2,alpha"`
+	DalytranCatCode      int64           `cobol:"DALYTRAN-CAT-CD,18,4,zoned_uint"`
+	DalytranSource       string          `cobol:"DALYTRAN-SOURCE,22,10,alpha"`
+	DalytranDesc         string          `cobol:"DALYTRAN-DESC,32,100,alpha"`
+	DalytranAmt          decimal.Decimal `cobol:"DALYTRAN-AMT,132,11,zoned_s2"`
+	DalytranMerchantID   int64           `cobol:"DALYTRAN-MERCHANT-ID,143,9,zoned_uint"`
+	DalytranMerchantName string          `cobol:"DALYTRAN-MERCHANT-NAME,152,50,alpha"`
+	DalytranMerchantCity string          `cobol:"DALYTRAN-MERCHANT-CITY,202,50,alpha"`
+	DalytranMerchantZip  string          `cobol:"DALYTRAN-MERCHANT-ZIP,252,10,alpha"`
+	DalytranCardNum      string          `cobol:"DALYTRAN-CARD-NUM,262,16,alpha"`
+	DalytranOrigTS       string          `cobol:"DALYTRAN-ORIG-TS,278,26,alpha"`
+	DalytranProcTS       string          `cobol:"DALYTRAN-PROC-TS,304,26,alpha"`
+}
+
+// DailyTransactionRecordLen is the fixed length of a DALYTRAN-RECORD in bytes.
+const DailyTransactionRecordLen = 350
+
+// DecodeDailyTransactionRecord decodes one 350-byte EBCDIC record into a DailyTransactionRecord.
+func DecodeDailyTransactionRecord(b []byte) (*DailyTransactionRecord, error) {
+	if len(b) < DailyTransactionRecordLen {
+		return nil, fmt.Errorf("domain: dalytran: record too short: got %d, want %d", len(b), DailyTransactionRecordLen)
+	}
+	b = b[:DailyTransactionRecordLen]
+
+	var r DailyTransactionRecord
+	var err error
+
+	alphaFields := []struct {
+		dst    *string
+		offset int
+		length int
+		label  string
+	}{
+		{&r.DalytranID, 0, 16, "DALYTRAN-ID"},
+		{&r.DalytranTypeCode, 16, 2, "DALYTRAN-TYPE-CD"},
+		{&r.DalytranSource, 22, 10, "DALYTRAN-SOURCE"},
+		{&r.DalytranDesc, 32, 100, "DALYTRAN-DESC"},
+		{&r.DalytranMerchantName, 152, 50, "DALYTRAN-MERCHANT-NAME"},
+		{&r.DalytranMerchantCity, 202, 50, "DALYTRAN-MERCHANT-CITY"},
+		{&r.DalytranMerchantZip, 252, 10, "DALYTRAN-MERCHANT-ZIP"},
+		{&r.DalytranCardNum, 262, 16, "DALYTRAN-CARD-NUM"},
+		{&r.DalytranOrigTS, 278, 26, "DALYTRAN-ORIG-TS"},
+		{&r.DalytranProcTS, 304, 26, "DALYTRAN-PROC-TS"},
+	}
+	for _, af := range alphaFields {
+		*af.dst, err = cobolfmt.DecodeEBCDICTrimmed(b[af.offset : af.offset+af.length])
+		if err != nil {
+			return nil, fmt.Errorf("domain: dalytran: %s: %w", af.label, err)
+		}
+	}
+
+	if r.DalytranCatCode, err = cobolfmt.DecodeZonedUint(b[18:22]); err != nil {
+		return nil, fmt.Errorf("domain: dalytran: DALYTRAN-CAT-CD: %w", err)
+	}
+	if r.DalytranAmt, err = cobolfmt.DecodeZoned(b[132:143], 2, true); err != nil {
+		return nil, fmt.Errorf("domain: dalytran: DALYTRAN-AMT: %w", err)
+	}
+	if r.DalytranMerchantID, err = cobolfmt.DecodeZonedUint(b[143:152]); err != nil {
+		return nil, fmt.Errorf("domain: dalytran: DALYTRAN-MERCHANT-ID: %w", err)
+	}
+
+	return &r, nil
+}
+
+// TrnxRecord is the Go port of TRNX-RECORD (COSTM01.CPY, 350 bytes).
+// Used for keyed VSAM access (key = TRNX-CARD-NUM + TRNX-ID).
+//
+// COBOL layout:
+//
+//	05 TRNX-KEY:
+//	   10 TRNX-CARD-NUM     PIC X(16)     offset   0 len 16
+//	   10 TRNX-ID           PIC X(16)     offset  16 len 16
+//	05 TRNX-REST:
+//	   10 TRNX-TYPE-CD      PIC X(02)     offset  32 len  2
+//	   10 TRNX-CAT-CD       PIC 9(04)     offset  34 len  4
+//	   10 TRNX-SOURCE       PIC X(10)     offset  38 len 10
+//	   10 TRNX-DESC         PIC X(100)    offset  48 len 100
+//	   10 TRNX-AMT          PIC S9(09)V99 offset 148 len 11
+//	   10 TRNX-MERCHANT-ID  PIC 9(09)     offset 159 len  9
+//	   10 TRNX-MERCHANT-NAME PIC X(50)    offset 168 len 50
+//	   10 TRNX-MERCHANT-CITY PIC X(50)    offset 218 len 50
+//	   10 TRNX-MERCHANT-ZIP  PIC X(10)    offset 268 len 10
+//	   10 TRNX-ORIG-TS      PIC X(26)     offset 278 len 26
+//	   10 TRNX-PROC-TS      PIC X(26)     offset 304 len 26
+//	   10 FILLER            PIC X(20)     offset 330 len 20
+type TrnxRecord struct {
+	TrnxCardNum      string          `cobol:"TRNX-CARD-NUM,0,16,alpha"`
+	TrnxID           string          `cobol:"TRNX-ID,16,16,alpha"`
+	TrnxTypeCode     string          `cobol:"TRNX-TYPE-CD,32,2,alpha"`
+	TrnxCatCode      int64           `cobol:"TRNX-CAT-CD,34,4,zoned_uint"`
+	TrnxSource       string          `cobol:"TRNX-SOURCE,38,10,alpha"`
+	TrnxDesc         string          `cobol:"TRNX-DESC,48,100,alpha"`
+	TrnxAmt          decimal.Decimal `cobol:"TRNX-AMT,148,11,zoned_s2"`
+	TrnxMerchantID   int64           `cobol:"TRNX-MERCHANT-ID,159,9,zoned_uint"`
+	TrnxMerchantName string          `cobol:"TRNX-MERCHANT-NAME,168,50,alpha"`
+	TrnxMerchantCity string          `cobol:"TRNX-MERCHANT-CITY,218,50,alpha"`
+	TrnxMerchantZip  string          `cobol:"TRNX-MERCHANT-ZIP,268,10,alpha"`
+	TrnxOrigTS       string          `cobol:"TRNX-ORIG-TS,278,26,alpha"`
+	TrnxProcTS       string          `cobol:"TRNX-PROC-TS,304,26,alpha"`
+}
+
+// TrnxRecordLen is the fixed length of a TRNX-RECORD in bytes.
+const TrnxRecordLen = 350
+
+// DecodeTrnxRecord decodes one 350-byte EBCDIC record into a TrnxRecord.
+func DecodeTrnxRecord(b []byte) (*TrnxRecord, error) {
+	if len(b) < TrnxRecordLen {
+		return nil, fmt.Errorf("domain: trnx: record too short: got %d, want %d", len(b), TrnxRecordLen)
+	}
+	b = b[:TrnxRecordLen]
+
+	var r TrnxRecord
+	var err error
+
+	alphaFields := []struct {
+		dst    *string
+		offset int
+		length int
+		label  string
+	}{
+		{&r.TrnxCardNum, 0, 16, "TRNX-CARD-NUM"},
+		{&r.TrnxID, 16, 16, "TRNX-ID"},
+		{&r.TrnxTypeCode, 32, 2, "TRNX-TYPE-CD"},
+		{&r.TrnxSource, 38, 10, "TRNX-SOURCE"},
+		{&r.TrnxDesc, 48, 100, "TRNX-DESC"},
+		{&r.TrnxMerchantName, 168, 50, "TRNX-MERCHANT-NAME"},
+		{&r.TrnxMerchantCity, 218, 50, "TRNX-MERCHANT-CITY"},
+		{&r.TrnxMerchantZip, 268, 10, "TRNX-MERCHANT-ZIP"},
+		{&r.TrnxOrigTS, 278, 26, "TRNX-ORIG-TS"},
+		{&r.TrnxProcTS, 304, 26, "TRNX-PROC-TS"},
+	}
+	for _, af := range alphaFields {
+		*af.dst, err = cobolfmt.DecodeEBCDICTrimmed(b[af.offset : af.offset+af.length])
+		if err != nil {
+			return nil, fmt.Errorf("domain: trnx: %s: %w", af.label, err)
+		}
+	}
+
+	if r.TrnxCatCode, err = cobolfmt.DecodeZonedUint(b[34:38]); err != nil {
+		return nil, fmt.Errorf("domain: trnx: TRNX-CAT-CD: %w", err)
+	}
+	if r.TrnxAmt, err = cobolfmt.DecodeZoned(b[148:159], 2, true); err != nil {
+		return nil, fmt.Errorf("domain: trnx: TRNX-AMT: %w", err)
+	}
+	if r.TrnxMerchantID, err = cobolfmt.DecodeZonedUint(b[159:168]); err != nil {
+		return nil, fmt.Errorf("domain: trnx: TRNX-MERCHANT-ID: %w", err)
+	}
+
+	return &r, nil
+}
+
+// DecodeTransactionRecords reads all TransactionRecords from a flat fixed-length binary file.
+func DecodeTransactionRecords(data []byte) ([]*TransactionRecord, error) {
+	if len(data)%TransactionRecordLen != 0 {
+		return nil, fmt.Errorf("domain: transaction: data length %d is not a multiple of %d", len(data), TransactionRecordLen)
+	}
+	count := len(data) / TransactionRecordLen
+	records := make([]*TransactionRecord, 0, count)
+	for i := 0; i < count; i++ {
+		rec, err := DecodeTransactionRecord(data[i*TransactionRecordLen : (i+1)*TransactionRecordLen])
+		if err != nil {
+			return nil, fmt.Errorf("domain: transaction: record %d: %w", i, err)
+		}
+		records = append(records, rec)
+	}
+	return records, nil
+}

--- a/internal/domain/transtype.go
+++ b/internal/domain/transtype.go
@@ -1,0 +1,358 @@
+package domain
+
+import (
+	"fmt"
+
+	"github.com/aws-samples/aws-mainframe-modernization-carddemo/internal/cobolfmt"
+	"github.com/shopspring/decimal"
+)
+
+// TranTypeRecord is the Go port of TRAN-TYPE-RECORD (CVTRA03Y.cpy, 60 bytes).
+//
+// COBOL layout:
+//
+//	05 TRAN-TYPE       PIC X(02)  offset  0 len  2
+//	05 TRAN-TYPE-DESC  PIC X(50)  offset  2 len 50
+//	05 FILLER          PIC X(08)  offset 52 len  8
+type TranTypeRecord struct {
+	TranType     string `cobol:"TRAN-TYPE,0,2,alpha"`
+	TranTypeDesc string `cobol:"TRAN-TYPE-DESC,2,50,alpha"`
+}
+
+// TranTypeRecordLen is the fixed length of a TRAN-TYPE-RECORD in bytes.
+const TranTypeRecordLen = 60
+
+// DecodeTranTypeRecord decodes one 60-byte EBCDIC record into a TranTypeRecord.
+func DecodeTranTypeRecord(b []byte) (*TranTypeRecord, error) {
+	if len(b) < TranTypeRecordLen {
+		return nil, fmt.Errorf("domain: trantype: record too short: got %d, want %d", len(b), TranTypeRecordLen)
+	}
+	b = b[:TranTypeRecordLen]
+
+	var r TranTypeRecord
+	var err error
+
+	if r.TranType, err = cobolfmt.DecodeEBCDICTrimmed(b[0:2]); err != nil {
+		return nil, fmt.Errorf("domain: trantype: TRAN-TYPE: %w", err)
+	}
+	if r.TranTypeDesc, err = cobolfmt.DecodeEBCDICTrimmed(b[2:52]); err != nil {
+		return nil, fmt.Errorf("domain: trantype: TRAN-TYPE-DESC: %w", err)
+	}
+
+	return &r, nil
+}
+
+// Encode serialises a TranTypeRecord back to its 60-byte EBCDIC representation.
+func (r *TranTypeRecord) Encode() ([]byte, error) {
+	out := make([]byte, TranTypeRecordLen)
+
+	ft, err := cobolfmt.EncodeEBCDIC(cobolfmt.PadRight(r.TranType, 2), 2)
+	if err != nil {
+		return nil, fmt.Errorf("domain: trantype: TRAN-TYPE: %w", err)
+	}
+	copy(out[0:2], ft)
+
+	fd, err := cobolfmt.EncodeEBCDIC(cobolfmt.PadRight(r.TranTypeDesc, 50), 50)
+	if err != nil {
+		return nil, fmt.Errorf("domain: trantype: TRAN-TYPE-DESC: %w", err)
+	}
+	copy(out[2:52], fd)
+
+	// FILLER is initialized to EBCDIC zeros (numeric initialization) in the fixtures.
+	copy(out[52:60], cobolfmt.EBCDICZeroPad(8))
+	return out, nil
+}
+
+// DecodeTranTypeRecords reads all TranTypeRecords from a flat fixed-length binary file.
+func DecodeTranTypeRecords(data []byte) ([]*TranTypeRecord, error) {
+	if len(data)%TranTypeRecordLen != 0 {
+		return nil, fmt.Errorf("domain: trantype: data length %d is not a multiple of %d", len(data), TranTypeRecordLen)
+	}
+	count := len(data) / TranTypeRecordLen
+	records := make([]*TranTypeRecord, 0, count)
+	for i := 0; i < count; i++ {
+		rec, err := DecodeTranTypeRecord(data[i*TranTypeRecordLen : (i+1)*TranTypeRecordLen])
+		if err != nil {
+			return nil, fmt.Errorf("domain: trantype: record %d: %w", i, err)
+		}
+		records = append(records, rec)
+	}
+	return records, nil
+}
+
+// TranCatRecord is the Go port of TRAN-CAT-RECORD (CVTRA04Y.cpy, 60 bytes).
+//
+// COBOL layout:
+//
+//	05 TRAN-CAT-KEY:
+//	   10 TRAN-TYPE-CD       PIC X(02)  offset  0 len  2
+//	   10 TRAN-CAT-CD        PIC 9(04)  offset  2 len  4
+//	05 TRAN-CAT-TYPE-DESC    PIC X(50)  offset  6 len 50
+//	05 FILLER                PIC X(04)  offset 56 len  4
+type TranCatRecord struct {
+	TranTypeCode    string `cobol:"TRAN-TYPE-CD,0,2,alpha"`
+	TranCatCode     int64  `cobol:"TRAN-CAT-CD,2,4,zoned_uint"`
+	TranCatTypeDesc string `cobol:"TRAN-CAT-TYPE-DESC,6,50,alpha"`
+}
+
+// TranCatRecordLen is the fixed length of a TRAN-CAT-RECORD in bytes.
+const TranCatRecordLen = 60
+
+// DecodeTranCatRecord decodes one 60-byte EBCDIC record into a TranCatRecord.
+func DecodeTranCatRecord(b []byte) (*TranCatRecord, error) {
+	if len(b) < TranCatRecordLen {
+		return nil, fmt.Errorf("domain: trancat: record too short: got %d, want %d", len(b), TranCatRecordLen)
+	}
+	b = b[:TranCatRecordLen]
+
+	var r TranCatRecord
+	var err error
+
+	if r.TranTypeCode, err = cobolfmt.DecodeEBCDICTrimmed(b[0:2]); err != nil {
+		return nil, fmt.Errorf("domain: trancat: TRAN-TYPE-CD: %w", err)
+	}
+	if r.TranCatCode, err = cobolfmt.DecodeZonedUint(b[2:6]); err != nil {
+		return nil, fmt.Errorf("domain: trancat: TRAN-CAT-CD: %w", err)
+	}
+	if r.TranCatTypeDesc, err = cobolfmt.DecodeEBCDICTrimmed(b[6:56]); err != nil {
+		return nil, fmt.Errorf("domain: trancat: TRAN-CAT-TYPE-DESC: %w", err)
+	}
+
+	return &r, nil
+}
+
+// Encode serialises a TranCatRecord back to its 60-byte EBCDIC representation.
+func (r *TranCatRecord) Encode() ([]byte, error) {
+	out := make([]byte, TranCatRecordLen)
+
+	ft, err := cobolfmt.EncodeEBCDIC(cobolfmt.PadRight(r.TranTypeCode, 2), 2)
+	if err != nil {
+		return nil, fmt.Errorf("domain: trancat: TRAN-TYPE-CD: %w", err)
+	}
+	copy(out[0:2], ft)
+
+	fc, err := cobolfmt.EncodeZonedUint(r.TranCatCode, 4)
+	if err != nil {
+		return nil, fmt.Errorf("domain: trancat: TRAN-CAT-CD: %w", err)
+	}
+	copy(out[2:6], fc)
+
+	fd, err := cobolfmt.EncodeEBCDIC(cobolfmt.PadRight(r.TranCatTypeDesc, 50), 50)
+	if err != nil {
+		return nil, fmt.Errorf("domain: trancat: TRAN-CAT-TYPE-DESC: %w", err)
+	}
+	copy(out[6:56], fd)
+
+	// FILLER is initialized to EBCDIC zeros in the fixtures.
+	copy(out[56:60], cobolfmt.EBCDICZeroPad(4))
+	return out, nil
+}
+
+// DecodeTranCatRecords reads all TranCatRecords from a flat fixed-length binary file.
+func DecodeTranCatRecords(data []byte) ([]*TranCatRecord, error) {
+	if len(data)%TranCatRecordLen != 0 {
+		return nil, fmt.Errorf("domain: trancat: data length %d is not a multiple of %d", len(data), TranCatRecordLen)
+	}
+	count := len(data) / TranCatRecordLen
+	records := make([]*TranCatRecord, 0, count)
+	for i := 0; i < count; i++ {
+		rec, err := DecodeTranCatRecord(data[i*TranCatRecordLen : (i+1)*TranCatRecordLen])
+		if err != nil {
+			return nil, fmt.Errorf("domain: trancat: record %d: %w", i, err)
+		}
+		records = append(records, rec)
+	}
+	return records, nil
+}
+
+// TranCatBalRecord is the Go port of TRAN-CAT-BAL-RECORD (CVTRA01Y.cpy, 50 bytes).
+//
+// COBOL layout:
+//
+//	05 TRAN-CAT-KEY:
+//	   10 TRANCAT-ACCT-ID   PIC 9(11)      offset  0 len 11
+//	   10 TRANCAT-TYPE-CD   PIC X(02)      offset 11 len  2
+//	   10 TRANCAT-CD        PIC 9(04)      offset 13 len  4
+//	05 TRAN-CAT-BAL         PIC S9(09)V99  offset 17 len 11
+//	05 FILLER               PIC X(22)      offset 28 len 22
+type TranCatBalRecord struct {
+	TrancatAcctID  int64           `cobol:"TRANCAT-ACCT-ID,0,11,zoned_uint"`
+	TrancatTypeCD  string          `cobol:"TRANCAT-TYPE-CD,11,2,alpha"`
+	TrancatCode    int64           `cobol:"TRANCAT-CD,13,4,zoned_uint"`
+	TranCatBalance decimal.Decimal `cobol:"TRAN-CAT-BAL,17,11,zoned_s2"`
+}
+
+// TranCatBalRecordLen is the fixed length of a TRAN-CAT-BAL-RECORD in bytes.
+const TranCatBalRecordLen = 50
+
+// DecodeTranCatBalRecord decodes one 50-byte EBCDIC record into a TranCatBalRecord.
+func DecodeTranCatBalRecord(b []byte) (*TranCatBalRecord, error) {
+	if len(b) < TranCatBalRecordLen {
+		return nil, fmt.Errorf("domain: tcatbal: record too short: got %d, want %d", len(b), TranCatBalRecordLen)
+	}
+	b = b[:TranCatBalRecordLen]
+
+	var r TranCatBalRecord
+	var err error
+
+	if r.TrancatAcctID, err = cobolfmt.DecodeZonedUint(b[0:11]); err != nil {
+		return nil, fmt.Errorf("domain: tcatbal: TRANCAT-ACCT-ID: %w", err)
+	}
+	if r.TrancatTypeCD, err = cobolfmt.DecodeEBCDICTrimmed(b[11:13]); err != nil {
+		return nil, fmt.Errorf("domain: tcatbal: TRANCAT-TYPE-CD: %w", err)
+	}
+	if r.TrancatCode, err = cobolfmt.DecodeZonedUint(b[13:17]); err != nil {
+		return nil, fmt.Errorf("domain: tcatbal: TRANCAT-CD: %w", err)
+	}
+	if r.TranCatBalance, err = cobolfmt.DecodeZoned(b[17:28], 2, true); err != nil {
+		return nil, fmt.Errorf("domain: tcatbal: TRAN-CAT-BAL: %w", err)
+	}
+
+	return &r, nil
+}
+
+// Encode serialises a TranCatBalRecord back to its 50-byte EBCDIC representation.
+func (r *TranCatBalRecord) Encode() ([]byte, error) {
+	out := make([]byte, TranCatBalRecordLen)
+
+	fid, err := cobolfmt.EncodeZonedUint(r.TrancatAcctID, 11)
+	if err != nil {
+		return nil, fmt.Errorf("domain: tcatbal: TRANCAT-ACCT-ID: %w", err)
+	}
+	copy(out[0:11], fid)
+
+	ft, err := cobolfmt.EncodeEBCDIC(cobolfmt.PadRight(r.TrancatTypeCD, 2), 2)
+	if err != nil {
+		return nil, fmt.Errorf("domain: tcatbal: TRANCAT-TYPE-CD: %w", err)
+	}
+	copy(out[11:13], ft)
+
+	fc, err := cobolfmt.EncodeZonedUint(r.TrancatCode, 4)
+	if err != nil {
+		return nil, fmt.Errorf("domain: tcatbal: TRANCAT-CD: %w", err)
+	}
+	copy(out[13:17], fc)
+
+	fb, err := cobolfmt.EncodeZoned(r.TranCatBalance, 11, 2, true)
+	if err != nil {
+		return nil, fmt.Errorf("domain: tcatbal: TRAN-CAT-BAL: %w", err)
+	}
+	copy(out[17:28], fb)
+
+	// FILLER is initialized to EBCDIC zeros in the fixtures.
+	copy(out[28:50], cobolfmt.EBCDICZeroPad(22))
+	return out, nil
+}
+
+// DecodeTranCatBalRecords reads all TranCatBalRecords from a flat fixed-length binary file.
+func DecodeTranCatBalRecords(data []byte) ([]*TranCatBalRecord, error) {
+	if len(data)%TranCatBalRecordLen != 0 {
+		return nil, fmt.Errorf("domain: tcatbal: data length %d is not a multiple of %d", len(data), TranCatBalRecordLen)
+	}
+	count := len(data) / TranCatBalRecordLen
+	records := make([]*TranCatBalRecord, 0, count)
+	for i := 0; i < count; i++ {
+		rec, err := DecodeTranCatBalRecord(data[i*TranCatBalRecordLen : (i+1)*TranCatBalRecordLen])
+		if err != nil {
+			return nil, fmt.Errorf("domain: tcatbal: record %d: %w", i, err)
+		}
+		records = append(records, rec)
+	}
+	return records, nil
+}
+
+// DiscGroupRecord is the Go port of DIS-GROUP-RECORD (CVTRA02Y.cpy, 50 bytes).
+//
+// COBOL layout:
+//
+//	05 DIS-GROUP-KEY:
+//	   10 DIS-ACCT-GROUP-ID  PIC X(10)      offset  0 len 10
+//	   10 DIS-TRAN-TYPE-CD   PIC X(02)      offset 10 len  2
+//	   10 DIS-TRAN-CAT-CD    PIC 9(04)      offset 12 len  4
+//	05 DIS-INT-RATE          PIC S9(04)V99  offset 16 len  6
+//	05 FILLER                PIC X(28)      offset 22 len 28
+type DiscGroupRecord struct {
+	DisAcctGroupID string          `cobol:"DIS-ACCT-GROUP-ID,0,10,alpha"`
+	DisTranTypeCD  string          `cobol:"DIS-TRAN-TYPE-CD,10,2,alpha"`
+	DisTranCatCode int64           `cobol:"DIS-TRAN-CAT-CD,12,4,zoned_uint"`
+	DisIntRate     decimal.Decimal `cobol:"DIS-INT-RATE,16,6,zoned_s2"`
+}
+
+// DiscGroupRecordLen is the fixed length of a DIS-GROUP-RECORD in bytes.
+const DiscGroupRecordLen = 50
+
+// DecodeDiscGroupRecord decodes one 50-byte EBCDIC record into a DiscGroupRecord.
+func DecodeDiscGroupRecord(b []byte) (*DiscGroupRecord, error) {
+	if len(b) < DiscGroupRecordLen {
+		return nil, fmt.Errorf("domain: discgrp: record too short: got %d, want %d", len(b), DiscGroupRecordLen)
+	}
+	b = b[:DiscGroupRecordLen]
+
+	var r DiscGroupRecord
+	var err error
+
+	if r.DisAcctGroupID, err = cobolfmt.DecodeEBCDICTrimmed(b[0:10]); err != nil {
+		return nil, fmt.Errorf("domain: discgrp: DIS-ACCT-GROUP-ID: %w", err)
+	}
+	if r.DisTranTypeCD, err = cobolfmt.DecodeEBCDICTrimmed(b[10:12]); err != nil {
+		return nil, fmt.Errorf("domain: discgrp: DIS-TRAN-TYPE-CD: %w", err)
+	}
+	if r.DisTranCatCode, err = cobolfmt.DecodeZonedUint(b[12:16]); err != nil {
+		return nil, fmt.Errorf("domain: discgrp: DIS-TRAN-CAT-CD: %w", err)
+	}
+	if r.DisIntRate, err = cobolfmt.DecodeZoned(b[16:22], 2, true); err != nil {
+		return nil, fmt.Errorf("domain: discgrp: DIS-INT-RATE: %w", err)
+	}
+
+	return &r, nil
+}
+
+// Encode serialises a DiscGroupRecord back to its 50-byte EBCDIC representation.
+func (r *DiscGroupRecord) Encode() ([]byte, error) {
+	out := make([]byte, DiscGroupRecordLen)
+
+	fg, err := cobolfmt.EncodeEBCDIC(cobolfmt.PadRight(r.DisAcctGroupID, 10), 10)
+	if err != nil {
+		return nil, fmt.Errorf("domain: discgrp: DIS-ACCT-GROUP-ID: %w", err)
+	}
+	copy(out[0:10], fg)
+
+	ft, err := cobolfmt.EncodeEBCDIC(cobolfmt.PadRight(r.DisTranTypeCD, 2), 2)
+	if err != nil {
+		return nil, fmt.Errorf("domain: discgrp: DIS-TRAN-TYPE-CD: %w", err)
+	}
+	copy(out[10:12], ft)
+
+	fc, err := cobolfmt.EncodeZonedUint(r.DisTranCatCode, 4)
+	if err != nil {
+		return nil, fmt.Errorf("domain: discgrp: DIS-TRAN-CAT-CD: %w", err)
+	}
+	copy(out[12:16], fc)
+
+	fr, err := cobolfmt.EncodeZoned(r.DisIntRate, 6, 2, true)
+	if err != nil {
+		return nil, fmt.Errorf("domain: discgrp: DIS-INT-RATE: %w", err)
+	}
+	copy(out[16:22], fr)
+
+	// FILLER is initialized to EBCDIC zeros in the fixtures.
+	copy(out[22:50], cobolfmt.EBCDICZeroPad(28))
+	return out, nil
+}
+
+// DecodeDiscGroupRecords reads all DiscGroupRecords from a flat fixed-length binary file.
+func DecodeDiscGroupRecords(data []byte) ([]*DiscGroupRecord, error) {
+	if len(data)%DiscGroupRecordLen != 0 {
+		return nil, fmt.Errorf("domain: discgrp: data length %d is not a multiple of %d", len(data), DiscGroupRecordLen)
+	}
+	count := len(data) / DiscGroupRecordLen
+	records := make([]*DiscGroupRecord, 0, count)
+	for i := 0; i < count; i++ {
+		rec, err := DecodeDiscGroupRecord(data[i*DiscGroupRecordLen : (i+1)*DiscGroupRecordLen])
+		if err != nil {
+			return nil, fmt.Errorf("domain: discgrp: record %d: %w", i, err)
+		}
+		records = append(records, rec)
+	}
+	return records, nil
+}

--- a/internal/domain/usersec.go
+++ b/internal/domain/usersec.go
@@ -57,11 +57,11 @@ const (
 )
 
 var (
-	ErrUserIDEmpty    = errors.New("user id is required")
-	ErrUserIDTooLong  = errors.New("user id exceeds 8 characters")
-	ErrFirstNameEmpty = errors.New("first name is required")
-	ErrLastNameEmpty  = errors.New("last name is required")
-	ErrPasswordEmpty  = errors.New("password is required")
+	ErrUserIDEmpty     = errors.New("user id is required")
+	ErrUserIDTooLong   = errors.New("user id exceeds 8 characters")
+	ErrFirstNameEmpty  = errors.New("first name is required")
+	ErrLastNameEmpty   = errors.New("last name is required")
+	ErrPasswordEmpty   = errors.New("password is required")
 	ErrPasswordTooLong = errors.New("password exceeds 8 characters")
 	ErrInvalidUserType = errors.New("user type must be 'A' (admin) or 'U' (user)")
 )

--- a/internal/domain/usersec.go
+++ b/internal/domain/usersec.go
@@ -1,0 +1,106 @@
+// Package domain holds CardDemo domain types ported from COBOL copybooks.
+package domain
+
+import (
+	"errors"
+	"strings"
+)
+
+// UserType mirrors SEC-USR-TYPE in CSUSR01Y.cpy: 'A' = admin, 'U' = user.
+type UserType byte
+
+const (
+	UserTypeAdmin UserType = 'A'
+	UserTypeUser  UserType = 'U'
+)
+
+func (t UserType) Valid() bool { return t == UserTypeAdmin || t == UserTypeUser }
+
+func (t UserType) String() string {
+	switch t {
+	case UserTypeAdmin:
+		return "ADMIN"
+	case UserTypeUser:
+		return "USER"
+	}
+	return ""
+}
+
+// UserSec is the Go port of SEC-USER-DATA (CSUSR01Y.cpy, 80 bytes).
+//
+// COBOL layout:
+//
+//	05 SEC-USR-ID     PIC X(08)
+//	05 SEC-USR-FNAME  PIC X(20)
+//	05 SEC-USR-LNAME  PIC X(20)
+//	05 SEC-USR-PWD    PIC X(08)   -- on the mainframe; in Go we never store cleartext
+//	05 SEC-USR-TYPE   PIC X(01)
+//	05 SEC-USR-FILLER PIC X(23)
+//
+// PwdHash replaces the cleartext PIC X(08) password field. The legacy 8-char
+// limit is enforced on input (UserID, plaintext password) but the persisted
+// hash is bcrypt — there is no fixed-width password column in Go-land.
+type UserSec struct {
+	UserID    string
+	FirstName string
+	LastName  string
+	PwdHash   string
+	Type      UserType
+}
+
+// Field length limits taken straight from the copybook.
+const (
+	UserIDMaxLen    = 8
+	FirstNameMaxLen = 20
+	LastNameMaxLen  = 20
+	PasswordMaxLen  = 8
+)
+
+var (
+	ErrUserIDEmpty    = errors.New("user id is required")
+	ErrUserIDTooLong  = errors.New("user id exceeds 8 characters")
+	ErrFirstNameEmpty = errors.New("first name is required")
+	ErrLastNameEmpty  = errors.New("last name is required")
+	ErrPasswordEmpty  = errors.New("password is required")
+	ErrPasswordTooLong = errors.New("password exceeds 8 characters")
+	ErrInvalidUserType = errors.New("user type must be 'A' (admin) or 'U' (user)")
+)
+
+// NormalizeUserID matches COBOL FUNCTION UPPER-CASE on SEC-USR-ID: trim, upper.
+func NormalizeUserID(id string) string {
+	return strings.ToUpper(strings.TrimSpace(id))
+}
+
+// ValidateUserInput validates the human-supplied parts of a UserSec record
+// (everything except the password hash, which is produced separately).
+func ValidateUserInput(userID, first, last string, t UserType) error {
+	id := strings.TrimSpace(userID)
+	if id == "" {
+		return ErrUserIDEmpty
+	}
+	if len(id) > UserIDMaxLen {
+		return ErrUserIDTooLong
+	}
+	if strings.TrimSpace(first) == "" {
+		return ErrFirstNameEmpty
+	}
+	if strings.TrimSpace(last) == "" {
+		return ErrLastNameEmpty
+	}
+	if !t.Valid() {
+		return ErrInvalidUserType
+	}
+	return nil
+}
+
+// ValidatePassword enforces the legacy 8-char ceiling on the *plaintext* the
+// caller supplies. The stored bcrypt hash is unbounded.
+func ValidatePassword(pw string) error {
+	if pw == "" {
+		return ErrPasswordEmpty
+	}
+	if len(pw) > PasswordMaxLen {
+		return ErrPasswordTooLong
+	}
+	return nil
+}

--- a/internal/domain/usersec_record.go
+++ b/internal/domain/usersec_record.go
@@ -1,0 +1,106 @@
+package domain
+
+import (
+	"fmt"
+
+	"github.com/aws-samples/aws-mainframe-modernization-carddemo/internal/cobolfmt"
+)
+
+// UserSecRecord is the raw EBCDIC layout of SEC-USER-DATA (CSUSR01Y.cpy, 80 bytes).
+// This is distinct from UserSec (the domain model) which uses bcrypt for the password.
+//
+// COBOL layout:
+//
+//	05 SEC-USR-ID     PIC X(08)  offset  0 len  8
+//	05 SEC-USR-FNAME  PIC X(20)  offset  8 len 20
+//	05 SEC-USR-LNAME  PIC X(20)  offset 28 len 20
+//	05 SEC-USR-PWD    PIC X(08)  offset 48 len  8  (plaintext on mainframe)
+//	05 SEC-USR-TYPE   PIC X(01)  offset 56 len  1
+//	05 SEC-USR-FILLER PIC X(23)  offset 57 len 23
+type UserSecRecord struct {
+	UserID    string `cobol:"SEC-USR-ID,0,8,alpha"`
+	FirstName string `cobol:"SEC-USR-FNAME,8,20,alpha"`
+	LastName  string `cobol:"SEC-USR-LNAME,28,20,alpha"`
+	Password  string `cobol:"SEC-USR-PWD,48,8,alpha"`
+	UserType  string `cobol:"SEC-USR-TYPE,56,1,alpha"`
+}
+
+// UserSecRecordLen is the fixed length of a SEC-USER-DATA record in bytes.
+const UserSecRecordLen = 80
+
+// DecodeUserSecRecord decodes one 80-byte EBCDIC record into a UserSecRecord.
+func DecodeUserSecRecord(b []byte) (*UserSecRecord, error) {
+	if len(b) < UserSecRecordLen {
+		return nil, fmt.Errorf("domain: usersec: record too short: got %d, want %d", len(b), UserSecRecordLen)
+	}
+	b = b[:UserSecRecordLen]
+
+	var r UserSecRecord
+	var err error
+
+	fields := []struct {
+		dst    *string
+		offset int
+		length int
+		label  string
+	}{
+		{&r.UserID, 0, 8, "SEC-USR-ID"},
+		{&r.FirstName, 8, 20, "SEC-USR-FNAME"},
+		{&r.LastName, 28, 20, "SEC-USR-LNAME"},
+		{&r.Password, 48, 8, "SEC-USR-PWD"},
+		{&r.UserType, 56, 1, "SEC-USR-TYPE"},
+	}
+	for _, f := range fields {
+		*f.dst, err = cobolfmt.DecodeEBCDICTrimmed(b[f.offset : f.offset+f.length])
+		if err != nil {
+			return nil, fmt.Errorf("domain: usersec: %s: %w", f.label, err)
+		}
+	}
+
+	return &r, nil
+}
+
+// Encode serialises a UserSecRecord back to its 80-byte EBCDIC representation.
+func (r *UserSecRecord) Encode() ([]byte, error) {
+	out := make([]byte, UserSecRecordLen)
+
+	fields := []struct {
+		val    string
+		offset int
+		length int
+		label  string
+	}{
+		{r.UserID, 0, 8, "SEC-USR-ID"},
+		{r.FirstName, 8, 20, "SEC-USR-FNAME"},
+		{r.LastName, 28, 20, "SEC-USR-LNAME"},
+		{r.Password, 48, 8, "SEC-USR-PWD"},
+		{r.UserType, 56, 1, "SEC-USR-TYPE"},
+	}
+	for _, f := range fields {
+		fb, ferr := cobolfmt.EncodeEBCDIC(cobolfmt.PadRight(f.val, f.length), f.length)
+		if ferr != nil {
+			return nil, fmt.Errorf("domain: usersec: %s: %w", f.label, ferr)
+		}
+		copy(out[f.offset:f.offset+f.length], fb)
+	}
+
+	copy(out[57:80], cobolfmt.EBCDICSpacePad(23))
+	return out, nil
+}
+
+// DecodeUserSecRecords reads all UserSecRecords from a flat fixed-length binary file.
+func DecodeUserSecRecords(data []byte) ([]*UserSecRecord, error) {
+	if len(data)%UserSecRecordLen != 0 {
+		return nil, fmt.Errorf("domain: usersec: data length %d is not a multiple of %d", len(data), UserSecRecordLen)
+	}
+	count := len(data) / UserSecRecordLen
+	records := make([]*UserSecRecord, 0, count)
+	for i := 0; i < count; i++ {
+		rec, err := DecodeUserSecRecord(data[i*UserSecRecordLen : (i+1)*UserSecRecordLen])
+		if err != nil {
+			return nil, fmt.Errorf("domain: usersec: record %d: %w", i, err)
+		}
+		records = append(records, rec)
+	}
+	return records, nil
+}

--- a/internal/repo/doc.go
+++ b/internal/repo/doc.go
@@ -1,0 +1,17 @@
+// Package repo provides repository interfaces and implementations for CardDemo persistence.
+//
+// VSAM KSDS files are replaced by a single relational backend:
+// SQLite (modernc.org/sqlite, CGO-free) for development and integration tests,
+// PostgreSQL (pgx/v5/stdlib) for production (ADR 0004).
+//
+// Callers program to interfaces only; no SQL is allowed outside this package.
+//
+// VSAM file → repository interface mapping:
+//
+//	USRSEC  (VSAM)  → UserSecRepository   (implemented: InMemoryUserSec)
+//	ACCTDAT (VSAM)  → AccountRepository   (RAU-38)
+//	CARDDAT (VSAM)  → CardRepository      (RAU-40)
+//	CUSTDAT (VSAM)  → CustomerRepository  (RAU-37)
+//	TRANSACT(VSAM)  → TransactionRepository (RAU-41)
+//	CARDXREF(VSAM)  → CardXrefRepository  (RAU-40)
+package repo

--- a/internal/repo/usersec.go
+++ b/internal/repo/usersec.go
@@ -1,0 +1,99 @@
+// Package repo defines persistence interfaces and an in-memory implementation
+// for the user-security store (USRSEC VSAM file in the legacy system).
+//
+// The interface is the contract RAU-38 will eventually back with a real KV/SQL
+// store; the in-memory impl exists so the auth + admin flows can run and be
+// tested today.
+package repo
+
+import (
+	"context"
+	"errors"
+	"sort"
+	"sync"
+
+	"github.com/aws-samples/aws-mainframe-modernization-carddemo/internal/domain"
+)
+
+var (
+	ErrNotFound = errors.New("user not found")
+	ErrConflict = errors.New("user already exists")
+)
+
+// UserSecRepo mirrors the VSAM/KSDS operations the COBOL programs perform on
+// the USRSEC dataset (READ / WRITE / REWRITE / DELETE / browse).
+type UserSecRepo interface {
+	Get(ctx context.Context, userID string) (domain.UserSec, error)
+	Create(ctx context.Context, u domain.UserSec) error
+	Update(ctx context.Context, u domain.UserSec) error
+	Delete(ctx context.Context, userID string) error
+	List(ctx context.Context) ([]domain.UserSec, error)
+}
+
+// InMemoryUserSec is a thread-safe map-backed UserSecRepo. Production code will
+// swap this for the persistent implementation from RAU-38.
+type InMemoryUserSec struct {
+	mu    sync.RWMutex
+	users map[string]domain.UserSec
+}
+
+func NewInMemoryUserSec() *InMemoryUserSec {
+	return &InMemoryUserSec{users: make(map[string]domain.UserSec)}
+}
+
+func (r *InMemoryUserSec) Get(_ context.Context, userID string) (domain.UserSec, error) {
+	id := domain.NormalizeUserID(userID)
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	u, ok := r.users[id]
+	if !ok {
+		return domain.UserSec{}, ErrNotFound
+	}
+	return u, nil
+}
+
+func (r *InMemoryUserSec) Create(_ context.Context, u domain.UserSec) error {
+	id := domain.NormalizeUserID(u.UserID)
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if _, exists := r.users[id]; exists {
+		return ErrConflict
+	}
+	u.UserID = id
+	r.users[id] = u
+	return nil
+}
+
+func (r *InMemoryUserSec) Update(_ context.Context, u domain.UserSec) error {
+	id := domain.NormalizeUserID(u.UserID)
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if _, exists := r.users[id]; !exists {
+		return ErrNotFound
+	}
+	u.UserID = id
+	r.users[id] = u
+	return nil
+}
+
+func (r *InMemoryUserSec) Delete(_ context.Context, userID string) error {
+	id := domain.NormalizeUserID(userID)
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if _, exists := r.users[id]; !exists {
+		return ErrNotFound
+	}
+	delete(r.users, id)
+	return nil
+}
+
+func (r *InMemoryUserSec) List(_ context.Context) ([]domain.UserSec, error) {
+	r.mu.RLock()
+	out := make([]domain.UserSec, 0, len(r.users))
+	for _, u := range r.users {
+		out = append(out, u)
+	}
+	r.mu.RUnlock()
+	sort.Slice(out, func(i, j int) bool { return out[i].UserID < out[j].UserID })
+	return out, nil
+}

--- a/internal/service/doc.go
+++ b/internal/service/doc.go
@@ -1,0 +1,23 @@
+// Package service contains CardDemo business-logic services.
+//
+// Services orchestrate domain types and repositories; they hold no SQL and
+// no HTTP concerns. Each service maps to one or more COBOL online programs.
+//
+// COBOL program → service mapping:
+//
+//	COACTUPC.cbl  → AccountService.Update   (account update, RAU-38)
+//	COACTVWC.cbl  → AccountService.View     (account view, RAU-38)
+//	COBIL00C.cbl  → BillingService          (bill payment, RAU-42)
+//	COCRDLIC.cbl  → CardService.List        (card list, RAU-40)
+//	COCRDSLC.cbl  → CardService.Select      (card select, RAU-40)
+//	COCRDUPC.cbl  → CardService.Update      (card update, RAU-40)
+//	COMEN01C.cbl  → MenuService             (main menu, RAU-43)
+//	CORPT00C.cbl  → ReportService           (transaction report, RAU-45)
+//	COTRN00C.cbl  → TransactionService.List (transaction list, RAU-41)
+//	COTRN01C.cbl  → TransactionService.Add  (add transaction, RAU-41)
+//	COTRN02C.cbl  → TransactionService.View (view transaction, RAU-41)
+//	COUSR00C.cbl  → UserService.List        (user list, RAU-39)
+//	COUSR01C.cbl  → UserService.Add         (add user, RAU-39)
+//	COUSR02C.cbl  → UserService.Update      (update user, RAU-39)
+//	COUSR03C.cbl  → UserService.Delete      (delete user, RAU-39)
+package service

--- a/internal/web/auth/handlers.go
+++ b/internal/web/auth/handlers.go
@@ -1,0 +1,468 @@
+// Package auth (web/auth) is the HTTP edge for sign-on and admin user CRUD.
+// It is the Go replacement for the COBOL programs:
+//
+//	COSGN00C  -> POST /login, GET /login, POST /logout
+//	COUSR00C  -> GET  /admin/users
+//	COUSR01C  -> POST /admin/users          (add)
+//	COUSR02C  -> POST /admin/users/{id}     (update)
+//	COUSR03C  -> POST /admin/users/{id}/delete  (delete; HTML form, no DELETE verb)
+//
+// Handlers render minimal HTML for browsers and JSON for Accept: application/json.
+package auth
+
+import (
+	"encoding/json"
+	"errors"
+	"html/template"
+	"net/http"
+	"strings"
+
+	authpkg "github.com/aws-samples/aws-mainframe-modernization-carddemo/internal/auth"
+	"github.com/aws-samples/aws-mainframe-modernization-carddemo/internal/domain"
+	"github.com/aws-samples/aws-mainframe-modernization-carddemo/internal/repo"
+)
+
+// Handlers exposes the HTTP entry points. Wire it with Routes().
+type Handlers struct {
+	Service       *authpkg.Service
+	CookieOptions authpkg.CookieOptions
+	LoginPath     string // typically "/login"
+	HomePath      string // where to send a USER after successful login
+	AdminPath     string // where to send an ADMIN after successful login
+}
+
+func NewHandlers(svc *authpkg.Service) *Handlers {
+	return &Handlers{
+		Service:       svc,
+		CookieOptions: authpkg.DefaultCookieOptions(),
+		LoginPath:     "/login",
+		HomePath:      "/",
+		AdminPath:     "/admin/users",
+	}
+}
+
+// Routes registers all handlers on the given mux. Caller is responsible for
+// wrapping the admin subtree with LoadSession + RequireAdmin + CSRFProtect;
+// the login routes need only LoadSession + CSRFProtect.
+func (h *Handlers) Routes(mux *http.ServeMux) {
+	mux.HandleFunc("GET /login", h.GetLogin)
+	mux.HandleFunc("POST /login", h.PostLogin)
+	mux.HandleFunc("POST /logout", h.PostLogout)
+
+	mux.HandleFunc("GET /admin/users", h.ListUsers)
+	mux.HandleFunc("POST /admin/users", h.CreateUser)
+	mux.HandleFunc("GET /admin/users/{id}", h.GetUser)
+	mux.HandleFunc("POST /admin/users/{id}", h.UpdateUser)
+	mux.HandleFunc("POST /admin/users/{id}/delete", h.DeleteUser)
+}
+
+// ---- Login / logout ---------------------------------------------------------
+
+func (h *Handlers) GetLogin(w http.ResponseWriter, r *http.Request) {
+	if _, ok := authpkg.SessionFromContext(r.Context()); ok {
+		http.Redirect(w, r, h.HomePath, http.StatusSeeOther)
+		return
+	}
+	// We render a fresh CSRF token so even an anonymous form submit can be
+	// double-submitted. We bind it to a short-lived "pre-session" cookie.
+	preCSRF, err := authpkg.NewCSRFToken()
+	if err != nil {
+		http.Error(w, "internal error", http.StatusInternalServerError)
+		return
+	}
+	authpkg.SetPreLoginCSRFCookie(w, preCSRF, h.CookieOptions)
+	renderLogin(w, loginView{CSRFToken: preCSRF})
+}
+
+type loginRequest struct {
+	UserID   string `json:"user_id"`
+	Password string `json:"password"`
+}
+
+func (h *Handlers) PostLogin(w http.ResponseWriter, r *http.Request) {
+	if _, ok := authpkg.SessionFromContext(r.Context()); ok {
+		http.Redirect(w, r, h.HomePath, http.StatusSeeOther)
+		return
+	}
+	// CSRFProtect middleware has already validated the double-submit token
+	// against the carddemo_csrf cookie set on GET /login.
+
+	userID, password, err := readLoginInput(r)
+	if err != nil {
+		http.Error(w, "bad request", http.StatusBadRequest)
+		return
+	}
+
+	sess, err := h.Service.Login(r.Context(), userID, password, authpkg.ClientIP(r))
+	if err != nil {
+		switch {
+		case errors.Is(err, authpkg.ErrRateLimited):
+			respondLoginError(w, r, "Too many attempts. Try again later.", http.StatusTooManyRequests)
+		default:
+			respondLoginError(w, r, "Invalid user id or password.", http.StatusUnauthorized)
+		}
+		return
+	}
+
+	authpkg.SetSessionCookie(w, sess, h.CookieOptions)
+	dest := h.HomePath
+	if sess.IsAdmin() {
+		dest = h.AdminPath
+	}
+	if wantsJSON(r) {
+		writeJSON(w, http.StatusOK, map[string]string{
+			"user_id":   sess.UserID,
+			"user_type": string(sess.UserType),
+			"redirect":  dest,
+		})
+		return
+	}
+	http.Redirect(w, r, dest, http.StatusSeeOther)
+}
+
+func (h *Handlers) PostLogout(w http.ResponseWriter, r *http.Request) {
+	if sess, ok := authpkg.SessionFromContext(r.Context()); ok {
+		_ = h.Service.Logout(r.Context(), sess, authpkg.ClientIP(r))
+	}
+	authpkg.ClearSessionCookies(w, h.CookieOptions)
+	if wantsJSON(r) {
+		w.WriteHeader(http.StatusNoContent)
+		return
+	}
+	http.Redirect(w, r, h.LoginPath, http.StatusSeeOther)
+}
+
+// ---- Admin user CRUD --------------------------------------------------------
+
+func (h *Handlers) ListUsers(w http.ResponseWriter, r *http.Request) {
+	users, err := h.Service.ListUsers(r.Context())
+	if err != nil {
+		http.Error(w, "internal error", http.StatusInternalServerError)
+		return
+	}
+	sess, _ := authpkg.SessionFromContext(r.Context())
+	if wantsJSON(r) {
+		writeJSON(w, http.StatusOK, map[string]any{"users": stripHashes(users)})
+		return
+	}
+	renderAdminList(w, adminListView{
+		Users:     stripHashes(users),
+		CSRFToken: sess.CSRFToken,
+	})
+}
+
+func (h *Handlers) GetUser(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+	u, err := h.Service.GetUser(r.Context(), id)
+	if err != nil {
+		http.Error(w, "not found", http.StatusNotFound)
+		return
+	}
+	if wantsJSON(r) {
+		writeJSON(w, http.StatusOK, stripHash(u))
+		return
+	}
+	sess, _ := authpkg.SessionFromContext(r.Context())
+	renderAdminEdit(w, adminEditView{User: stripHash(u), CSRFToken: sess.CSRFToken})
+}
+
+type userMutationRequest struct {
+	UserID    string `json:"user_id"`
+	FirstName string `json:"first_name"`
+	LastName  string `json:"last_name"`
+	Password  string `json:"password"`
+	UserType  string `json:"user_type"`
+}
+
+func (h *Handlers) CreateUser(w http.ResponseWriter, r *http.Request) {
+	req, err := readMutationInput(r)
+	if err != nil {
+		http.Error(w, "bad request", http.StatusBadRequest)
+		return
+	}
+	t, err := parseUserType(req.UserType)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	sess, _ := authpkg.SessionFromContext(r.Context())
+	err = h.Service.CreateUser(r.Context(), sess.UserID, req.UserID, req.FirstName, req.LastName, req.Password, t, authpkg.ClientIP(r))
+	if err != nil {
+		writeMutationError(w, r, err)
+		return
+	}
+	if wantsJSON(r) {
+		w.WriteHeader(http.StatusCreated)
+		return
+	}
+	http.Redirect(w, r, h.AdminPath, http.StatusSeeOther)
+}
+
+func (h *Handlers) UpdateUser(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+	req, err := readMutationInput(r)
+	if err != nil {
+		http.Error(w, "bad request", http.StatusBadRequest)
+		return
+	}
+	t, err := parseUserType(req.UserType)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	sess, _ := authpkg.SessionFromContext(r.Context())
+	err = h.Service.UpdateUser(r.Context(), sess.UserID, id, req.FirstName, req.LastName, req.Password, t, authpkg.ClientIP(r))
+	if err != nil {
+		writeMutationError(w, r, err)
+		return
+	}
+	if wantsJSON(r) {
+		w.WriteHeader(http.StatusOK)
+		return
+	}
+	http.Redirect(w, r, h.AdminPath, http.StatusSeeOther)
+}
+
+func (h *Handlers) DeleteUser(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+	sess, _ := authpkg.SessionFromContext(r.Context())
+	if err := h.Service.DeleteUser(r.Context(), sess.UserID, id, authpkg.ClientIP(r)); err != nil {
+		writeMutationError(w, r, err)
+		return
+	}
+	if wantsJSON(r) {
+		w.WriteHeader(http.StatusNoContent)
+		return
+	}
+	http.Redirect(w, r, h.AdminPath, http.StatusSeeOther)
+}
+
+// ---- helpers ---------------------------------------------------------------
+
+func readLoginInput(r *http.Request) (string, string, error) {
+	if strings.HasPrefix(r.Header.Get("Content-Type"), "application/json") {
+		var lr loginRequest
+		if err := json.NewDecoder(r.Body).Decode(&lr); err != nil {
+			return "", "", err
+		}
+		return lr.UserID, lr.Password, nil
+	}
+	if err := r.ParseForm(); err != nil {
+		return "", "", err
+	}
+	return r.PostFormValue("user_id"), r.PostFormValue("password"), nil
+}
+
+func readMutationInput(r *http.Request) (userMutationRequest, error) {
+	if strings.HasPrefix(r.Header.Get("Content-Type"), "application/json") {
+		var req userMutationRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			return req, err
+		}
+		return req, nil
+	}
+	if err := r.ParseForm(); err != nil {
+		return userMutationRequest{}, err
+	}
+	return userMutationRequest{
+		UserID:    r.PostFormValue("user_id"),
+		FirstName: r.PostFormValue("first_name"),
+		LastName:  r.PostFormValue("last_name"),
+		Password:  r.PostFormValue("password"),
+		UserType:  r.PostFormValue("user_type"),
+	}, nil
+}
+
+func parseUserType(s string) (domain.UserType, error) {
+	s = strings.ToUpper(strings.TrimSpace(s))
+	switch s {
+	case "A", "ADMIN":
+		return domain.UserTypeAdmin, nil
+	case "U", "USER":
+		return domain.UserTypeUser, nil
+	}
+	return 0, domain.ErrInvalidUserType
+}
+
+func writeMutationError(w http.ResponseWriter, r *http.Request, err error) {
+	switch {
+	case errors.Is(err, repo.ErrConflict):
+		http.Error(w, "user already exists", http.StatusConflict)
+	case errors.Is(err, repo.ErrNotFound):
+		http.Error(w, "user not found", http.StatusNotFound)
+	case errors.Is(err, domain.ErrUserIDEmpty),
+		errors.Is(err, domain.ErrUserIDTooLong),
+		errors.Is(err, domain.ErrFirstNameEmpty),
+		errors.Is(err, domain.ErrLastNameEmpty),
+		errors.Is(err, domain.ErrPasswordEmpty),
+		errors.Is(err, domain.ErrPasswordTooLong),
+		errors.Is(err, domain.ErrInvalidUserType):
+		http.Error(w, err.Error(), http.StatusBadRequest)
+	default:
+		http.Error(w, "internal error", http.StatusInternalServerError)
+	}
+	_ = r // r kept for future logging hooks
+}
+
+func wantsJSON(r *http.Request) bool {
+	a := r.Header.Get("Accept")
+	return strings.Contains(strings.ToLower(a), "application/json") ||
+		strings.HasPrefix(r.Header.Get("Content-Type"), "application/json")
+}
+
+func writeJSON(w http.ResponseWriter, status int, body any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(body)
+}
+
+// publicUser is what we serialize back to clients — the bcrypt hash never leaves the server.
+type publicUser struct {
+	UserID    string `json:"user_id"`
+	FirstName string `json:"first_name"`
+	LastName  string `json:"last_name"`
+	UserType  string `json:"user_type"`
+}
+
+func stripHash(u domain.UserSec) publicUser {
+	return publicUser{
+		UserID:    u.UserID,
+		FirstName: u.FirstName,
+		LastName:  u.LastName,
+		UserType:  string(u.Type),
+	}
+}
+
+func stripHashes(us []domain.UserSec) []publicUser {
+	out := make([]publicUser, len(us))
+	for i, u := range us {
+		out[i] = stripHash(u)
+	}
+	return out
+}
+
+func respondLoginError(w http.ResponseWriter, r *http.Request, msg string, status int) {
+	if wantsJSON(r) {
+		writeJSON(w, status, map[string]string{"error": msg})
+		return
+	}
+	w.WriteHeader(status)
+	renderLogin(w, loginView{Error: msg, CSRFToken: preLoginCSRFFromRequest(r)})
+}
+
+func preLoginCSRFFromRequest(r *http.Request) string {
+	c, err := r.Cookie(authpkg.CSRFCookieName)
+	if err != nil {
+		return ""
+	}
+	return c.Value
+}
+
+// ---- views (tiny inline templates) -----------------------------------------
+
+type loginView struct {
+	Error     string
+	CSRFToken string
+}
+
+type adminListView struct {
+	Users     []publicUser
+	CSRFToken string
+}
+
+type adminEditView struct {
+	User      publicUser
+	CSRFToken string
+}
+
+var (
+	loginTpl = template.Must(template.New("login").Parse(`<!doctype html>
+<html><head><title>CardDemo Sign-on</title></head><body>
+<h1>CardDemo Sign-on</h1>
+{{if .Error}}<p style="color:red">{{.Error}}</p>{{end}}
+<form method="post" action="/login">
+  <input type="hidden" name="csrf_token" value="{{.CSRFToken}}">
+  <label>User ID <input name="user_id" maxlength="8" required></label>
+  <label>Password <input type="password" name="password" maxlength="8" required></label>
+  <button type="submit">Sign on</button>
+</form>
+</body></html>`))
+
+	adminListTpl = template.Must(template.New("admin_list").Parse(`<!doctype html>
+<html><head><title>Admin · Users</title></head><body>
+<h1>Users</h1>
+<form method="post" action="/logout">
+  <input type="hidden" name="csrf_token" value="{{.CSRFToken}}">
+  <button type="submit">Sign off</button>
+</form>
+<table border="1">
+<tr><th>ID</th><th>First</th><th>Last</th><th>Type</th><th></th></tr>
+{{range .Users}}
+<tr>
+  <td><a href="/admin/users/{{.UserID}}">{{.UserID}}</a></td>
+  <td>{{.FirstName}}</td><td>{{.LastName}}</td><td>{{.UserType}}</td>
+  <td>
+    <form method="post" action="/admin/users/{{.UserID}}/delete" style="display:inline">
+      <input type="hidden" name="csrf_token" value="{{$.CSRFToken}}">
+      <button type="submit">Delete</button>
+    </form>
+  </td>
+</tr>
+{{end}}
+</table>
+<h2>Add user</h2>
+<form method="post" action="/admin/users">
+  <input type="hidden" name="csrf_token" value="{{.CSRFToken}}">
+  <label>User ID <input name="user_id" maxlength="8" required></label>
+  <label>First <input name="first_name" maxlength="20" required></label>
+  <label>Last <input name="last_name" maxlength="20" required></label>
+  <label>Password <input type="password" name="password" maxlength="8" required></label>
+  <label>Type
+    <select name="user_type">
+      <option value="U">User</option>
+      <option value="A">Admin</option>
+    </select>
+  </label>
+  <button type="submit">Add</button>
+</form>
+</body></html>`))
+
+	adminEditTpl = template.Must(template.New("admin_edit").Parse(`<!doctype html>
+<html><head><title>Edit {{.User.UserID}}</title></head><body>
+<h1>Edit {{.User.UserID}}</h1>
+<form method="post" action="/admin/users/{{.User.UserID}}">
+  <input type="hidden" name="csrf_token" value="{{.CSRFToken}}">
+  <input type="hidden" name="user_id" value="{{.User.UserID}}">
+  <label>First <input name="first_name" value="{{.User.FirstName}}" maxlength="20" required></label>
+  <label>Last  <input name="last_name"  value="{{.User.LastName}}"  maxlength="20" required></label>
+  <label>New Password (leave blank to keep) <input type="password" name="password" maxlength="8"></label>
+  <label>Type
+    <select name="user_type">
+      <option value="U" {{if eq .User.UserType "U"}}selected{{end}}>User</option>
+      <option value="A" {{if eq .User.UserType "A"}}selected{{end}}>Admin</option>
+    </select>
+  </label>
+  <button type="submit">Save</button>
+</form>
+<form method="post" action="/admin/users/{{.User.UserID}}/delete">
+  <input type="hidden" name="csrf_token" value="{{.CSRFToken}}">
+  <button type="submit">Delete</button>
+</form>
+<a href="/admin/users">Back</a>
+</body></html>`))
+)
+
+func renderLogin(w http.ResponseWriter, v loginView) {
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	_ = loginTpl.Execute(w, v)
+}
+
+func renderAdminList(w http.ResponseWriter, v adminListView) {
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	_ = adminListTpl.Execute(w, v)
+}
+
+func renderAdminEdit(w http.ResponseWriter, v adminEditView) {
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	_ = adminEditTpl.Execute(w, v)
+}

--- a/internal/web/auth/handlers_test.go
+++ b/internal/web/auth/handlers_test.go
@@ -1,0 +1,351 @@
+package auth
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/cookiejar"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/aws-samples/aws-mainframe-modernization-carddemo/internal/audit"
+	authpkg "github.com/aws-samples/aws-mainframe-modernization-carddemo/internal/auth"
+	"github.com/aws-samples/aws-mainframe-modernization-carddemo/internal/domain"
+	"github.com/aws-samples/aws-mainframe-modernization-carddemo/internal/repo"
+)
+
+type testServer struct {
+	srv      *httptest.Server
+	client   *http.Client
+	store    *authpkg.MemorySessionStore
+	users    *repo.InMemoryUserSec
+	sink     *audit.MemorySink
+	handlers *Handlers
+	svc      *authpkg.Service
+}
+
+func newTestServer(t *testing.T) *testServer {
+	t.Helper()
+	users := repo.NewInMemoryUserSec()
+	if err := authpkg.SeedDefaultUsers(context.Background(), users, 4); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	sink := audit.NewMemorySink()
+	store := authpkg.NewMemorySessionStore()
+	svc := authpkg.NewService(users, store, sink)
+
+	h := NewHandlers(svc)
+	h.CookieOptions.Secure = false // httptest is plain HTTP
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /login", h.GetLogin)
+	mux.HandleFunc("POST /login", h.PostLogin)
+	mux.HandleFunc("POST /logout", h.PostLogout)
+
+	adminMux := http.NewServeMux()
+	adminMux.HandleFunc("GET /admin/users", h.ListUsers)
+	adminMux.HandleFunc("POST /admin/users", h.CreateUser)
+	adminMux.HandleFunc("GET /admin/users/{id}", h.GetUser)
+	adminMux.HandleFunc("POST /admin/users/{id}", h.UpdateUser)
+	adminMux.HandleFunc("POST /admin/users/{id}/delete", h.DeleteUser)
+
+	mux.Handle("/admin/", authpkg.RequireAdmin(sink, h.LoginPath)(adminMux))
+
+	loadSession := authpkg.LoadSession(store)
+	csrf := authpkg.CSRFProtect()
+
+	srv := httptest.NewServer(loadSession(csrf(mux)))
+	t.Cleanup(srv.Close)
+
+	jar, _ := cookiejar.New(nil)
+	return &testServer{
+		srv:      srv,
+		client:   &http.Client{Jar: jar, CheckRedirect: func(req *http.Request, via []*http.Request) error { return http.ErrUseLastResponse }},
+		store:    store,
+		users:    users,
+		sink:     sink,
+		handlers: h,
+		svc:      svc,
+	}
+}
+
+func (ts *testServer) get(t *testing.T, path string, accept string) *http.Response {
+	t.Helper()
+	req, _ := http.NewRequest(http.MethodGet, ts.srv.URL+path, nil)
+	if accept != "" {
+		req.Header.Set("Accept", accept)
+	}
+	resp, err := ts.client.Do(req)
+	if err != nil {
+		t.Fatalf("GET %s: %v", path, err)
+	}
+	return resp
+}
+
+// loginCSRFToken fetches GET /login so the pre-login CSRF cookie is set on the
+// jar, then returns the token value for use in the form post.
+func (ts *testServer) loginCSRFToken(t *testing.T) string {
+	t.Helper()
+	resp := ts.get(t, "/login", "text/html")
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("GET /login: %d", resp.StatusCode)
+	}
+	u, _ := url.Parse(ts.srv.URL)
+	for _, c := range ts.client.Jar.Cookies(u) {
+		if c.Name == authpkg.CSRFCookieName {
+			return c.Value
+		}
+	}
+	t.Fatal("pre-login csrf cookie not set")
+	return ""
+}
+
+// sessionCSRFToken returns the CSRF token tied to the current session cookie.
+func (ts *testServer) sessionCSRFToken(t *testing.T) string {
+	t.Helper()
+	u, _ := url.Parse(ts.srv.URL)
+	for _, c := range ts.client.Jar.Cookies(u) {
+		if c.Name == authpkg.CSRFCookieName {
+			return c.Value
+		}
+	}
+	t.Fatal("session csrf cookie not set")
+	return ""
+}
+
+func (ts *testServer) postForm(t *testing.T, path string, form url.Values) *http.Response {
+	t.Helper()
+	req, _ := http.NewRequest(http.MethodPost, ts.srv.URL+path, strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	resp, err := ts.client.Do(req)
+	if err != nil {
+		t.Fatalf("POST %s: %v", path, err)
+	}
+	return resp
+}
+
+func (ts *testServer) login(t *testing.T, userID, password string) *http.Response {
+	t.Helper()
+	tok := ts.loginCSRFToken(t)
+	form := url.Values{}
+	form.Set("user_id", userID)
+	form.Set("password", password)
+	form.Set(authpkg.CSRFFormField, tok)
+	return ts.postForm(t, "/login", form)
+}
+
+// ---- Tests ------------------------------------------------------------------
+
+func TestEndToEndAcceptanceFlow(t *testing.T) {
+	// Issue acceptance: seed → POST /login as ADMIN001 → GET /admin/users (200)
+	//                   → as USER0001 → GET /admin/users (403).
+	ts := newTestServer(t)
+
+	// Admin login
+	resp := ts.login(t, "ADMIN001", "PASSWORD")
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusSeeOther {
+		t.Fatalf("admin login: want 303, got %d", resp.StatusCode)
+	}
+	if loc := resp.Header.Get("Location"); loc != "/admin/users" {
+		t.Fatalf("admin login redirect: got %q", loc)
+	}
+
+	resp = ts.get(t, "/admin/users", "text/html")
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("admin GET /admin/users: want 200, got %d", resp.StatusCode)
+	}
+
+	// Sign off
+	logoutForm := url.Values{}
+	logoutForm.Set(authpkg.CSRFFormField, ts.sessionCSRFToken(t))
+	resp = ts.postForm(t, "/logout", logoutForm)
+	resp.Body.Close()
+
+	// Regular user login
+	resp = ts.login(t, "USER0001", "PASSWORD")
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusSeeOther {
+		t.Fatalf("user login: want 303, got %d", resp.StatusCode)
+	}
+	if loc := resp.Header.Get("Location"); loc != "/" {
+		t.Fatalf("user login redirect: got %q (admins go to /admin/users, users go home)", loc)
+	}
+
+	// Regular user is forbidden from admin pages
+	resp = ts.get(t, "/admin/users", "text/html")
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("user GET /admin/users: want 403, got %d", resp.StatusCode)
+	}
+	// Audit must record the access denial.
+	if ts.sink.CountByAction(audit.ActionAccessDenied) != 1 {
+		t.Fatalf("expected 1 access.denied audit, got %d", ts.sink.CountByAction(audit.ActionAccessDenied))
+	}
+}
+
+func TestLoginRejectsMissingCSRF(t *testing.T) {
+	ts := newTestServer(t)
+	// Skip the GET /login step that would set the pre-login CSRF cookie.
+	form := url.Values{}
+	form.Set("user_id", "ADMIN001")
+	form.Set("password", "PASSWORD")
+	resp := ts.postForm(t, "/login", form)
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("expected 403 without CSRF, got %d", resp.StatusCode)
+	}
+}
+
+func TestLoginWithBadCSRFRejected(t *testing.T) {
+	ts := newTestServer(t)
+	_ = ts.loginCSRFToken(t) // pre-login cookie set, but use the wrong value
+	form := url.Values{}
+	form.Set("user_id", "ADMIN001")
+	form.Set("password", "PASSWORD")
+	form.Set(authpkg.CSRFFormField, "tampered")
+	resp := ts.postForm(t, "/login", form)
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("expected 403 with bad CSRF, got %d", resp.StatusCode)
+	}
+}
+
+func TestUnauthenticatedAdminRedirects(t *testing.T) {
+	ts := newTestServer(t)
+	resp := ts.get(t, "/admin/users", "text/html")
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusSeeOther {
+		t.Fatalf("anon GET /admin/users: want 303, got %d", resp.StatusCode)
+	}
+	if loc := resp.Header.Get("Location"); loc != "/login" {
+		t.Fatalf("expected redirect to /login, got %q", loc)
+	}
+}
+
+func TestSessionCookieFlags(t *testing.T) {
+	ts := newTestServer(t)
+	resp := ts.login(t, "ADMIN001", "PASSWORD")
+	resp.Body.Close()
+	var sessCookie *http.Cookie
+	for _, c := range resp.Cookies() {
+		if c.Name == authpkg.SessionCookieName {
+			sessCookie = c
+		}
+	}
+	if sessCookie == nil {
+		t.Fatal("session cookie not set")
+	}
+	if !sessCookie.HttpOnly {
+		t.Fatal("session cookie must be HttpOnly")
+	}
+	if sessCookie.SameSite != http.SameSiteLaxMode {
+		t.Fatalf("session cookie SameSite=Lax required, got %v", sessCookie.SameSite)
+	}
+	// Secure flag is toggled off in tests because httptest is plain HTTP, but
+	// cookies set in production via DefaultCookieOptions() should be Secure.
+	if defOpts := authpkg.DefaultCookieOptions(); !defOpts.Secure {
+		t.Fatal("DefaultCookieOptions must produce Secure cookies in production")
+	}
+}
+
+func TestBruteForceLockoutOverHTTP(t *testing.T) {
+	// End-to-end variant of the rate-limit test, hitting the HTTP edge so the
+	// CSRF + session machinery is exercised at the same time.
+	ts := newTestServer(t)
+	// Tighten the per-user limit so we don't have to send 5 attempts per test.
+	ts.svc.UserLimiter = authpkg.NewRateLimiter(2, 15*60*1_000_000_000) // 15min in ns
+
+	for i := 0; i < 2; i++ {
+		resp := ts.login(t, "ADMIN001", "wrong")
+		resp.Body.Close()
+		if resp.StatusCode != http.StatusUnauthorized {
+			t.Fatalf("attempt %d: want 401, got %d", i, resp.StatusCode)
+		}
+	}
+	// Next attempt — even with the right password — must be 429.
+	resp := ts.login(t, "ADMIN001", "PASSWORD")
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusTooManyRequests {
+		t.Fatalf("expected 429 after lockout, got %d", resp.StatusCode)
+	}
+}
+
+func TestAdminCreateUpdateDeleteUserOverHTTP(t *testing.T) {
+	ts := newTestServer(t)
+	resp := ts.login(t, "ADMIN001", "PASSWORD")
+	resp.Body.Close()
+	tok := ts.sessionCSRFToken(t)
+
+	// Create
+	form := url.Values{}
+	form.Set(authpkg.CSRFFormField, tok)
+	form.Set("user_id", "OP01")
+	form.Set("first_name", "Op")
+	form.Set("last_name", "Erator")
+	form.Set("password", "secret")
+	form.Set("user_type", "U")
+	resp = ts.postForm(t, "/admin/users", form)
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusSeeOther {
+		t.Fatalf("create: want 303, got %d", resp.StatusCode)
+	}
+	got, err := ts.users.Get(context.Background(), "OP01")
+	if err != nil {
+		t.Fatalf("user not created: %v", err)
+	}
+	if got.PwdHash == "secret" {
+		t.Fatal("stored password must be hashed")
+	}
+
+	// JSON GET (and verify hash never leaks)
+	req, _ := http.NewRequest(http.MethodGet, ts.srv.URL+"/admin/users/OP01", nil)
+	req.Header.Set("Accept", "application/json")
+	resp, _ = ts.client.Do(req)
+	body := map[string]any{}
+	json.NewDecoder(resp.Body).Decode(&body)
+	resp.Body.Close()
+	if _, leaked := body["pwd_hash"]; leaked {
+		t.Fatal("password hash leaked over JSON")
+	}
+
+	// Update
+	form = url.Values{}
+	form.Set(authpkg.CSRFFormField, tok)
+	form.Set("first_name", "Operator")
+	form.Set("last_name", "Smith")
+	form.Set("user_type", "A")
+	resp = ts.postForm(t, "/admin/users/OP01", form)
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusSeeOther {
+		t.Fatalf("update: want 303, got %d", resp.StatusCode)
+	}
+	got, _ = ts.users.Get(context.Background(), "OP01")
+	if got.FirstName != "Operator" || got.LastName != "Smith" || got.Type != domain.UserTypeAdmin {
+		t.Fatalf("update did not stick: %+v", got)
+	}
+
+	// Delete
+	form = url.Values{}
+	form.Set(authpkg.CSRFFormField, tok)
+	resp = ts.postForm(t, "/admin/users/OP01/delete", form)
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusSeeOther {
+		t.Fatalf("delete: want 303, got %d", resp.StatusCode)
+	}
+	if _, err := ts.users.Get(context.Background(), "OP01"); err == nil {
+		t.Fatal("user not deleted")
+	}
+
+	// Audit covers the lifecycle.
+	for _, a := range []audit.Action{audit.ActionUserCreate, audit.ActionUserUpdate, audit.ActionUserDelete} {
+		if ts.sink.CountByAction(a) != 1 {
+			t.Fatalf("expected 1 %s audit, got %d", a, ts.sink.CountByAction(a))
+		}
+	}
+}
+

--- a/internal/web/auth/handlers_test.go
+++ b/internal/web/auth/handlers_test.go
@@ -71,12 +71,21 @@ func newTestServer(t *testing.T) *testServer {
 	}
 }
 
-func (ts *testServer) get(t *testing.T, path string, accept string) *http.Response {
+func (ts *testServer) get(t *testing.T, path string) *http.Response {
 	t.Helper()
 	req, _ := http.NewRequest(http.MethodGet, ts.srv.URL+path, nil)
-	if accept != "" {
-		req.Header.Set("Accept", accept)
+	req.Header.Set("Accept", "text/html")
+	resp, err := ts.client.Do(req)
+	if err != nil {
+		t.Fatalf("GET %s: %v", path, err)
 	}
+	return resp
+}
+
+func (ts *testServer) getJSON(t *testing.T, path string) *http.Response {
+	t.Helper()
+	req, _ := http.NewRequest(http.MethodGet, ts.srv.URL+path, nil)
+	req.Header.Set("Accept", "application/json")
 	resp, err := ts.client.Do(req)
 	if err != nil {
 		t.Fatalf("GET %s: %v", path, err)
@@ -88,8 +97,8 @@ func (ts *testServer) get(t *testing.T, path string, accept string) *http.Respon
 // jar, then returns the token value for use in the form post.
 func (ts *testServer) loginCSRFToken(t *testing.T) string {
 	t.Helper()
-	resp := ts.get(t, "/login", "text/html")
-	defer resp.Body.Close()
+	resp := ts.get(t, "/login")
+	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode != http.StatusOK {
 		t.Fatalf("GET /login: %d", resp.StatusCode)
 	}
@@ -146,7 +155,7 @@ func TestEndToEndAcceptanceFlow(t *testing.T) {
 
 	// Admin login
 	resp := ts.login(t, "ADMIN001", "PASSWORD")
-	resp.Body.Close()
+	_ = resp.Body.Close()
 	if resp.StatusCode != http.StatusSeeOther {
 		t.Fatalf("admin login: want 303, got %d", resp.StatusCode)
 	}
@@ -154,8 +163,8 @@ func TestEndToEndAcceptanceFlow(t *testing.T) {
 		t.Fatalf("admin login redirect: got %q", loc)
 	}
 
-	resp = ts.get(t, "/admin/users", "text/html")
-	resp.Body.Close()
+	resp = ts.get(t, "/admin/users")
+	_ = resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
 		t.Fatalf("admin GET /admin/users: want 200, got %d", resp.StatusCode)
 	}
@@ -164,11 +173,11 @@ func TestEndToEndAcceptanceFlow(t *testing.T) {
 	logoutForm := url.Values{}
 	logoutForm.Set(authpkg.CSRFFormField, ts.sessionCSRFToken(t))
 	resp = ts.postForm(t, "/logout", logoutForm)
-	resp.Body.Close()
+	_ = resp.Body.Close()
 
 	// Regular user login
 	resp = ts.login(t, "USER0001", "PASSWORD")
-	resp.Body.Close()
+	_ = resp.Body.Close()
 	if resp.StatusCode != http.StatusSeeOther {
 		t.Fatalf("user login: want 303, got %d", resp.StatusCode)
 	}
@@ -177,8 +186,8 @@ func TestEndToEndAcceptanceFlow(t *testing.T) {
 	}
 
 	// Regular user is forbidden from admin pages
-	resp = ts.get(t, "/admin/users", "text/html")
-	resp.Body.Close()
+	resp = ts.get(t, "/admin/users")
+	_ = resp.Body.Close()
 	if resp.StatusCode != http.StatusForbidden {
 		t.Fatalf("user GET /admin/users: want 403, got %d", resp.StatusCode)
 	}
@@ -195,7 +204,7 @@ func TestLoginRejectsMissingCSRF(t *testing.T) {
 	form.Set("user_id", "ADMIN001")
 	form.Set("password", "PASSWORD")
 	resp := ts.postForm(t, "/login", form)
-	resp.Body.Close()
+	_ = resp.Body.Close()
 	if resp.StatusCode != http.StatusForbidden {
 		t.Fatalf("expected 403 without CSRF, got %d", resp.StatusCode)
 	}
@@ -209,7 +218,7 @@ func TestLoginWithBadCSRFRejected(t *testing.T) {
 	form.Set("password", "PASSWORD")
 	form.Set(authpkg.CSRFFormField, "tampered")
 	resp := ts.postForm(t, "/login", form)
-	resp.Body.Close()
+	_ = resp.Body.Close()
 	if resp.StatusCode != http.StatusForbidden {
 		t.Fatalf("expected 403 with bad CSRF, got %d", resp.StatusCode)
 	}
@@ -217,8 +226,8 @@ func TestLoginWithBadCSRFRejected(t *testing.T) {
 
 func TestUnauthenticatedAdminRedirects(t *testing.T) {
 	ts := newTestServer(t)
-	resp := ts.get(t, "/admin/users", "text/html")
-	resp.Body.Close()
+	resp := ts.get(t, "/admin/users")
+	_ = resp.Body.Close()
 	if resp.StatusCode != http.StatusSeeOther {
 		t.Fatalf("anon GET /admin/users: want 303, got %d", resp.StatusCode)
 	}
@@ -230,7 +239,7 @@ func TestUnauthenticatedAdminRedirects(t *testing.T) {
 func TestSessionCookieFlags(t *testing.T) {
 	ts := newTestServer(t)
 	resp := ts.login(t, "ADMIN001", "PASSWORD")
-	resp.Body.Close()
+	_ = resp.Body.Close()
 	var sessCookie *http.Cookie
 	for _, c := range resp.Cookies() {
 		if c.Name == authpkg.SessionCookieName {
@@ -262,14 +271,14 @@ func TestBruteForceLockoutOverHTTP(t *testing.T) {
 
 	for i := 0; i < 2; i++ {
 		resp := ts.login(t, "ADMIN001", "wrong")
-		resp.Body.Close()
+		_ = resp.Body.Close()
 		if resp.StatusCode != http.StatusUnauthorized {
 			t.Fatalf("attempt %d: want 401, got %d", i, resp.StatusCode)
 		}
 	}
 	// Next attempt — even with the right password — must be 429.
 	resp := ts.login(t, "ADMIN001", "PASSWORD")
-	resp.Body.Close()
+	_ = resp.Body.Close()
 	if resp.StatusCode != http.StatusTooManyRequests {
 		t.Fatalf("expected 429 after lockout, got %d", resp.StatusCode)
 	}
@@ -278,7 +287,7 @@ func TestBruteForceLockoutOverHTTP(t *testing.T) {
 func TestAdminCreateUpdateDeleteUserOverHTTP(t *testing.T) {
 	ts := newTestServer(t)
 	resp := ts.login(t, "ADMIN001", "PASSWORD")
-	resp.Body.Close()
+	_ = resp.Body.Close()
 	tok := ts.sessionCSRFToken(t)
 
 	// Create
@@ -290,7 +299,7 @@ func TestAdminCreateUpdateDeleteUserOverHTTP(t *testing.T) {
 	form.Set("password", "secret")
 	form.Set("user_type", "U")
 	resp = ts.postForm(t, "/admin/users", form)
-	resp.Body.Close()
+	_ = resp.Body.Close()
 	if resp.StatusCode != http.StatusSeeOther {
 		t.Fatalf("create: want 303, got %d", resp.StatusCode)
 	}
@@ -303,12 +312,12 @@ func TestAdminCreateUpdateDeleteUserOverHTTP(t *testing.T) {
 	}
 
 	// JSON GET (and verify hash never leaks)
-	req, _ := http.NewRequest(http.MethodGet, ts.srv.URL+"/admin/users/OP01", nil)
-	req.Header.Set("Accept", "application/json")
-	resp, _ = ts.client.Do(req)
+	resp = ts.getJSON(t, "/admin/users/OP01")
 	body := map[string]any{}
-	json.NewDecoder(resp.Body).Decode(&body)
-	resp.Body.Close()
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("decode json: %v", err)
+	}
+	_ = resp.Body.Close()
 	if _, leaked := body["pwd_hash"]; leaked {
 		t.Fatal("password hash leaked over JSON")
 	}
@@ -320,7 +329,7 @@ func TestAdminCreateUpdateDeleteUserOverHTTP(t *testing.T) {
 	form.Set("last_name", "Smith")
 	form.Set("user_type", "A")
 	resp = ts.postForm(t, "/admin/users/OP01", form)
-	resp.Body.Close()
+	_ = resp.Body.Close()
 	if resp.StatusCode != http.StatusSeeOther {
 		t.Fatalf("update: want 303, got %d", resp.StatusCode)
 	}
@@ -333,7 +342,7 @@ func TestAdminCreateUpdateDeleteUserOverHTTP(t *testing.T) {
 	form = url.Values{}
 	form.Set(authpkg.CSRFFormField, tok)
 	resp = ts.postForm(t, "/admin/users/OP01/delete", form)
-	resp.Body.Close()
+	_ = resp.Body.Close()
 	if resp.StatusCode != http.StatusSeeOther {
 		t.Fatalf("delete: want 303, got %d", resp.StatusCode)
 	}
@@ -348,4 +357,3 @@ func TestAdminCreateUpdateDeleteUserOverHTTP(t *testing.T) {
 		}
 	}
 }
-

--- a/internal/web/doc.go
+++ b/internal/web/doc.go
@@ -1,0 +1,26 @@
+// Package web contains the CardDemo HTTP handlers and routing (ADR 0003).
+//
+// Each BMS map becomes one HTTP handler returning html/template output.
+// The chi router (github.com/go-chi/chi/v5) provides URL params and middleware
+// composition. Handlers depend on service interfaces, not repositories directly.
+//
+// BMS map → handler subpackage mapping:
+//
+//	COSGN00.bms  → web/auth     (sign-on / sign-off, RAU-39 ✓ done)
+//	COADM01.bms  → web/admin    (admin menu, RAU-39 ✓ done)
+//	COMEN01.bms  → web/menu     (main menu, RAU-43)
+//	COACTVW.bms  → web/account  (account view, RAU-38)
+//	COACTUP.bms  → web/account  (account update, RAU-38)
+//	COCRDSL.bms  → web/card     (card select, RAU-40)
+//	COCRDLI.bms  → web/card     (card list, RAU-40)
+//	COCRDUP.bms  → web/card     (card update, RAU-40)
+//	COTRN00.bms  → web/txn      (transaction list, RAU-41)
+//	COTRN01.bms  → web/txn      (add transaction, RAU-41)
+//	COTRN02.bms  → web/txn      (view transaction, RAU-41)
+//	COBIL00.bms  → web/billing  (bill payment, RAU-42)
+//	CORPT00.bms  → web/report   (transaction report, RAU-45)
+//	COUSR00.bms  → web/user     (user list, RAU-39 ✓ done)
+//	COUSR01.bms  → web/user     (add user, RAU-39 ✓ done)
+//	COUSR02.bms  → web/user     (update user, RAU-39 ✓ done)
+//	COUSR03.bms  → web/user     (delete user, RAU-39 ✓ done)
+package web


### PR DESCRIPTION
## Summary
- Implements `internal/cobolfmt` package: EBCDIC↔UTF-8 (CP037 via `golang.org/x/text`), zoned decimal encode/decode, COMP-3 packed decimal, COMP/COMP-4 binary, date/timestamp helpers
- Implements `internal/domain` structs for all 11 record-bearing copybooks: Account, Card, CardXref, Customer, Transaction, DailyTransaction, TrnxRecord, TranType, TranCat, TranCatBal, DiscGroup, UserSecRecord (raw EBCDIC layout companion to existing UserSec domain model)
- Adds `github.com/shopspring/decimal` (ADR 0007) and `golang.org/x/text` dependencies

## Test plan
- [x] Table-driven unit tests: zoned decimal (signed/unsigned/negative), COMP-3 (odd/even digits, negative), binary COMP, EBCDIC round-trip of all printable ASCII, date windowing (YY>=40->19xx), leap-year (2000-02-29), timestamp round-trips
- [x] Round-trip property tests against 8 EBCDIC fixture files — decode -> encode -> byte-identical verified:
  - account×50, customer×50, card×50, cardxref×50 records
  - trantype×7, trancat×18, discgrp×51, tcatbal×50 records
  - usrsec×10 records
- [x] go test ./... passes all packages

## Acceptance
- go test ./internal/domain/... ./internal/cobolfmt/... passes ✅
- A struct exists for every record-bearing copybook ✅
- Round-trip test against account, card, customer EBCDIC fixtures passes byte-for-byte ✅ (plus 5 additional fixture files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)