### PR TITLE
Fix ACCT-UPDATE-RECORD layout drift corrupting account master on update

### DIFF
--- a/app/cbl/COACTUPC.cbl
+++ b/app/cbl/COACTUPC.cbl
@@ -429,8 +429,9 @@
                15  ACCT-UPDATE-REISSUE-DATE            PIC X(10).
                15  ACCT-UPDATE-CURR-CYC-CREDIT         PIC S9(10)V99.
                15  ACCT-UPDATE-CURR-CYC-DEBIT          PIC S9(10)V99.
+               15  ACCT-UPDATE-ADDR-ZIP                PIC X(10).
                15  ACCT-UPDATE-GROUP-ID                PIC X(10).
-               15  FILLER                              PIC X(188).
+               15  FILLER                              PIC X(178).
           05 CUST-UPDATE-RECORD.
       *****************************************************************
       *    Data-structure for  CUSTOMER entity (RECLN 300)
@@ -3998,6 +3999,8 @@
                   ACUP-NEW-REISSUE-DAY
            DELIMITED BY SIZE
                                        INTO ACCT-UPDATE-REISSUE-DATE
+      * Account-level Zip (not edited on screen - carry existing value)
+           MOVE ACCT-ADDR-ZIP            TO ACCT-UPDATE-ADDR-ZIP
       * Account Group
            MOVE ACUP-NEW-GROUP-ID        TO ACCT-UPDATE-GROUP-ID
 


### PR DESCRIPTION
COACTUPC's ACCT-UPDATE-RECORD staging copy had drifted from the canonical ACCOUNT-RECORD layout (CVACT01Y): ACCT-ADDR-ZIP was dropped and the trailing FILLER padded X(178)->X(188) to keep 300 bytes, but ACCT-UPDATE-GROUP-ID was not kept at its correct offset. It slid onto the master's zip position, so every REWRITE silently overwrote ACCT-ADDR-ZIP with the group id and wiped ACCT-GROUP-ID with FILLER.

- Reinsert ACCT-UPDATE-ADDR-ZIP PIC X(10) before ACCT-UPDATE-GROUP-ID and restore FILLER to X(178), making the layout byte-identical to ACCOUNT-RECORD.
- Carry the existing ACCT-ADDR-ZIP through on rewrite (the screen does not edit the account-level zip) so updates no longer blank it.

I do not have a mainframe environment, so I cannot test it there directly. But I have been building a CICS emulation layer, and noticed this problem in the update in a test about updating fields.